### PR TITLE
Refactor Changes Endpoint

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
@@ -29,6 +29,7 @@ import com.urswolfer.gerrit.client.rest.http.accounts.AccountsParser;
 import com.urswolfer.gerrit.client.rest.http.accounts.AccountsRestClient;
 import com.urswolfer.gerrit.client.rest.http.changes.ChangesParser;
 import com.urswolfer.gerrit.client.rest.http.changes.ChangesRestClient;
+import com.urswolfer.gerrit.client.rest.http.changes.CommentsParser;
 import com.urswolfer.gerrit.client.rest.http.projects.ProjectsParser;
 import com.urswolfer.gerrit.client.rest.http.projects.ProjectsRestClient;
 import com.urswolfer.gerrit.client.rest.http.tools.ToolsRestClient;
@@ -44,7 +45,7 @@ public class GerritApiImpl extends GerritApi.NotImplemented implements GerritApi
                          HttpClientBuilderExtension... httpClientBuilderExtensions) {
         GerritRestClient gerritRestClient = new GerritRestClient(authData, httpRequestExecutor, httpClientBuilderExtensions);
         Gson gson = gerritRestClient.getGson();
-        changesRestClient = new ChangesRestClient(gerritRestClient, new ChangesParser(gson));
+        changesRestClient = new ChangesRestClient(gerritRestClient, new ChangesParser(gson), new CommentsParser(gson));
         accountsRestClient = new AccountsRestClient(gerritRestClient, new AccountsParser(gson));
         projectsRestClient = new ProjectsRestClient(gerritRestClient, new ProjectsParser(gson));
         toolsRestClient = new ToolsRestClient(gerritRestClient);

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
@@ -35,21 +35,26 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
 
     private final GerritRestClient gerritRestClient;
     private final ChangesRestClient changesRestClient;
+    private final CommentsParser commentsParser;
     private final String id;
 
     public ChangeApiRestClient(GerritRestClient gerritRestClient,
                                ChangesRestClient changesRestClient,
+                               CommentsParser commentsParser,
                                String triplet) {
         this.gerritRestClient = gerritRestClient;
         this.changesRestClient = changesRestClient;
+        this.commentsParser = commentsParser;
         this.id = triplet;
     }
 
     public ChangeApiRestClient(GerritRestClient gerritRestClient,
                                ChangesRestClient changesRestClient,
+                               CommentsParser commentsParser,
                                int id) {
         this.changesRestClient = changesRestClient;
         this.gerritRestClient = gerritRestClient;
+        this.commentsParser = commentsParser;
         this.id = "" + id;
     }
 
@@ -60,17 +65,17 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
 
     @Override
     public RevisionApi current() throws RestApiException {
-        return new RevisionApiRestClient(gerritRestClient, this, "current");
+        return new RevisionApiRestClient(gerritRestClient, this, commentsParser, "current");
     }
 
     @Override
     public RevisionApi revision(int id) throws RestApiException {
-        return new RevisionApiRestClient(gerritRestClient, this, "" + id);
+        return new RevisionApiRestClient(gerritRestClient, this, commentsParser, "" + id);
     }
 
     @Override
     public RevisionApi revision(String id) throws RestApiException {
-        return new RevisionApiRestClient(gerritRestClient, this, id);
+        return new RevisionApiRestClient(gerritRestClient, this, commentsParser, id);
     }
 
     @Override

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
@@ -35,11 +35,14 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
 
     private final GerritRestClient gerritRestClient;
     private final ChangesParser changesParser;
+    private final CommentsParser commentsParser;
 
     public ChangesRestClient(GerritRestClient gerritRestClient,
-                             ChangesParser changesParser) {
+                             ChangesParser changesParser,
+                             CommentsParser commentsParser) {
         this.gerritRestClient = gerritRestClient;
         this.changesParser = changesParser;
+        this.commentsParser = commentsParser;
     }
 
     @Override
@@ -84,16 +87,16 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
 
     @Override
     public ChangeApi id(int id) throws RestApiException {
-        return new ChangeApiRestClient(gerritRestClient, this, id);
+        return new ChangeApiRestClient(gerritRestClient, this, commentsParser, id);
     }
 
     @Override
     public ChangeApi id(String triplet) throws RestApiException {
-        return new ChangeApiRestClient(gerritRestClient, this, triplet);
+        return new ChangeApiRestClient(gerritRestClient, this, commentsParser, triplet);
     }
 
     @Override
     public ChangeApi id(String project, String branch, String id) throws RestApiException {
-        return new ChangeApiRestClient(gerritRestClient, this, String.format("%s~%s~%s", project, branch, id));
+        return new ChangeApiRestClient(gerritRestClient, this, commentsParser, String.format("%s~%s~%s", project, branch, id));
     }
 }

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/CommentsParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/CommentsParser.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2014 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gerrit.extensions.common.CommentInfo;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * @author Thomas Forrer
+ */
+public class CommentsParser {
+    private final Gson gson;
+
+    public CommentsParser(Gson gson) {
+        this.gson = gson;
+    }
+
+    public TreeMap<String, List<CommentInfo>> parseCommentInfos(JsonElement result) {
+        TreeMap<String, List<CommentInfo>> commentInfos = Maps.newTreeMap();
+        JsonObject jsonObject = result.getAsJsonObject();
+
+        for (Map.Entry<String, JsonElement> element : jsonObject.entrySet()) {
+            List<CommentInfo> currentCommentInfos = Lists.newArrayList();
+
+            for (JsonElement jsonElement : element.getValue().getAsJsonArray()) {
+                currentCommentInfos.add(parseSingleCommentInfos(jsonElement.getAsJsonObject()));
+            }
+
+            commentInfos.put(element.getKey(), currentCommentInfos);
+        }
+        return commentInfos;
+    }
+
+    private CommentInfo parseSingleCommentInfos(JsonObject result) {
+        return gson.fromJson(result, CommentInfo.class);
+    }
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
@@ -40,7 +40,7 @@ public class ChangeApiRestClientTest {
         ChangesRestClient changesRestClient = getChangesRestClient();
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(
-                gerritRestClient, changesRestClient,
+                gerritRestClient, changesRestClient, null,
                 "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         AddReviewerInput input = new AddReviewerInput();
@@ -60,7 +60,7 @@ public class ChangeApiRestClientTest {
         ChangesRestClient changesRestClient = getChangesRestClient();
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(
-                gerritRestClient, changesRestClient,
+                gerritRestClient, changesRestClient, null,
                 "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         changeApiRestClient.addReviewer("jdoe");

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
@@ -81,7 +81,7 @@ public class ChangesRestClientTest {
         GerritRestClient gerritRestClient = setupGerritRestClient(testCase);
         ChangesParser changesParser = setupChangesParser();
 
-        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser);
+        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null);
 
         Changes.QueryRequest queryRequest = changes.query();
         testCase.queryParameter.apply(queryRequest).get();
@@ -95,7 +95,7 @@ public class ChangesRestClientTest {
         GerritRestClient gerritRestClient = setupGerritRestClient(testCase);
         ChangesParser changesParser = setupChangesParser();
 
-        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser);
+        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null);
 
         changes.query().get();
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/CommentsParserTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/CommentsParserTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2013-2014 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.CommentInfo;
+import com.google.gson.JsonElement;
+import com.urswolfer.gerrit.client.rest.http.common.AbstractParserTest;
+import com.urswolfer.gerrit.client.rest.http.common.AccountInfoBuilder;
+import com.urswolfer.gerrit.client.rest.http.common.CommentInfoBuilder;
+import com.urswolfer.gerrit.client.rest.http.common.GerritAssert;
+import junit.framework.Assert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * @author Thomas Forrer
+ */
+public class CommentsParserTest extends AbstractParserTest {
+    private static final TreeMap<String, List<CommentInfo>> COMMENT_INFOS = Maps.newTreeMap();
+
+    static {
+        AccountInfo accountInfo = new AccountInfoBuilder()
+                .withName("Thomas Forrer")
+                .withEmail("forrert@gmail.com")
+                .withUsername("forrert")
+                .withAccountId(1000000)
+                .get();
+
+        COMMENT_INFOS.put("playingfield.iml", Lists.newArrayList(
+                        new CommentInfoBuilder()
+                                .withId("da33351e_8109fa2e")
+                                .withLine(1)
+                                .withMessage("is this really needed?")
+                                .withUpdated("2014-05-28 19:14:50")
+                                .withAuthor(accountInfo)
+                                .get()
+                ));
+        COMMENT_INFOS.put("src/ch/tf/playingfield/PlayingField.java", Lists.newArrayList(
+                new CommentInfoBuilder()
+                        .withId("da33351e_41fff201")
+                        .withMessage("looks good to me!")
+                        .withUpdated("2014-05-28 19:14:50")
+                        .withAuthor(accountInfo)
+                        .get(),
+                new CommentInfoBuilder()
+                        .withId("da33351e_21046e14")
+                        .withMessage("please reformat imports")
+                        .withUpdated("2014-05-28 19:14:50")
+                        .withLine(4)
+                        .withAuthor(accountInfo)
+                        .get()
+        ));
+    }
+
+    private CommentsParser commentsParser = new CommentsParser(getGson());
+
+    @Test
+    public void testParseCommentsFileName() throws Exception {
+        TreeMap<String, List<CommentInfo>> comments = parseComments();
+        Assert.assertEquals(comments.keySet(), COMMENT_INFOS.keySet());
+    }
+
+    @Test
+    public void testParseCommentInfosForFile() throws Exception {
+        TreeMap<String, List<CommentInfo>> comments = parseComments();
+        Function<List<CommentInfo>, Integer> listSizeFunction = new Function<List<CommentInfo>, Integer>() {
+            @Override
+            public Integer apply(List<CommentInfo> commentInfos) {
+                return commentInfos.size();
+            }
+        };
+        SortedMap<String, Integer> commentsPerFile = Maps.transformValues(comments, listSizeFunction);
+        SortedMap<String, Integer> expectedCommentsPerFile = Maps.transformValues(COMMENT_INFOS, listSizeFunction);
+
+        Assert.assertEquals(commentsPerFile, expectedCommentsPerFile);
+    }
+
+    @Test
+    public void testParseCommentInfos() throws Exception {
+        TreeMap<String, List<CommentInfo>> comments = parseComments();
+        GerritAssert.assertEquals(comments, COMMENT_INFOS);
+    }
+
+    private TreeMap<String, List<CommentInfo>> parseComments() throws Exception {
+        JsonElement jsonElement = getJsonElement("comments.json");
+        return commentsParser.parseCommentInfos(jsonElement);
+    }
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/AbstractBuilder.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/AbstractBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2013-2014 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.gerrit.client.rest.http.common;
+
+import com.google.common.base.Throwables;
+
+import java.sql.Timestamp;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+/**
+ * @author Thomas Forrer
+ */
+public class AbstractBuilder {
+    static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+    static {
+        DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    static Timestamp timestamp(String timestamp) {
+        try {
+            Date parse = DATE_FORMAT.parse(timestamp);
+            return new Timestamp(parse.getTime());
+        } catch (ParseException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/AccountInfoBuilder.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/AccountInfoBuilder.java
@@ -42,4 +42,9 @@ public final class AccountInfoBuilder {
         accountInfo.username = username;
         return this;
     }
+
+    public AccountInfoBuilder withAccountId(int id) {
+        accountInfo._accountId = id;
+        return this;
+    }
 }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/ChangeInfoBuilder.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/ChangeInfoBuilder.java
@@ -16,38 +16,19 @@
 
 package com.urswolfer.gerrit.client.rest.http.common;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import com.google.gerrit.extensions.common.*;
 
 import java.sql.Timestamp;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Collection;
-import java.util.Date;
 import java.util.Map;
-import java.util.TimeZone;
 
 /**
  * @author Thomas Forrer
  */
-public class ChangeInfoBuilder {
-    private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-
-    static {
-        DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
-    }
+public class ChangeInfoBuilder extends AbstractBuilder {
 
     private final ChangeInfo changeInfo = new ChangeInfo();
-
-    private static Timestamp timestamp(String timestamp) {
-        try {
-            Date parse = DATE_FORMAT.parse(timestamp);
-            return new Timestamp(parse.getTime());
-        } catch (ParseException e) {
-            throw Throwables.propagate(e);
-        }
-    }
 
     public ChangeInfo get() {
         return changeInfo;

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/CommentInfoBuilder.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/CommentInfoBuilder.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2013-2014 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.gerrit.client.rest.http.common;
+
+import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.Comment;
+import com.google.gerrit.extensions.common.CommentInfo;
+
+/**
+ * @author Thomas Forrer
+ */
+public class CommentInfoBuilder extends AbstractBuilder {
+    private final CommentInfo commentInfo = new CommentInfo();
+
+    public CommentInfo get() {
+        return commentInfo;
+    }
+
+    public CommentInfoBuilder withAuthor(AccountInfo author) {
+        commentInfo.author = author;
+        return this;
+    }
+
+    public CommentInfoBuilder withId(String id) {
+        commentInfo.id = id;
+        return this;
+    }
+
+    public CommentInfoBuilder withPath(String path) {
+        commentInfo.path = path;
+        return this;
+    }
+
+    public CommentInfoBuilder withSide(Comment.Side side) {
+        commentInfo.side = side;
+        return this;
+    }
+
+    public CommentInfoBuilder withLine(int line) {
+        commentInfo.line = line;
+        return this;
+    }
+
+    public CommentInfoBuilder withRange(Comment.Range range) {
+        commentInfo.range = range;
+        return this;
+    }
+
+    public CommentInfoBuilder withInReplyTo(String inReplyTo) {
+        commentInfo.inReplyTo = inReplyTo;
+        return this;
+    }
+
+    public CommentInfoBuilder withUpdated(String updated) {
+        commentInfo.updated = timestamp(updated);
+        return this;
+    }
+
+    public CommentInfoBuilder withMessage(String message) {
+        commentInfo.message = message;
+        return this;
+    }
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/GerritAssert.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/GerritAssert.java
@@ -18,9 +18,13 @@ package com.urswolfer.gerrit.client.rest.http.common;
 
 import com.google.gerrit.extensions.common.AccountInfo;
 import com.google.gerrit.extensions.common.ChangeInfo;
+import com.google.gerrit.extensions.common.CommentInfo;
 import com.google.gerrit.extensions.common.ProjectInfo;
 import com.thoughtworks.xstream.XStream;
 import org.testng.Assert;
+
+import java.util.List;
+import java.util.TreeMap;
 
 /**
  * @author Thomas Forrer
@@ -44,6 +48,10 @@ public class GerritAssert {
     }
 
     public static void assertEquals(AccountInfo actual, AccountInfo expected) {
+        assertXmlOutputEqual(actual, expected);
+    }
+
+    public static void assertEquals(TreeMap<String, List<CommentInfo>> actual, TreeMap<String, List<CommentInfo>> expected) {
         assertXmlOutputEqual(actual, expected);
     }
 

--- a/src/test/resources/com/urswolfer/gerrit/client/rest/http/changes/comments.json
+++ b/src/test/resources/com/urswolfer/gerrit/client/rest/http/changes/comments.json
@@ -1,0 +1,48 @@
+)]}'
+{
+    "playingfield.iml": [
+        {
+            "kind": "gerritcodereview#comment",
+            "id": "da33351e_8109fa2e",
+            "line": 1,
+            "message": "is this really needed?",
+            "updated": "2014-05-28 19:14:50.629000000",
+            "author": {
+                "_account_id": 1000000,
+                "name": "Thomas Forrer",
+                "email": "forrert@gmail.com",
+                "username": "forrert",
+                "avatars": []
+            }
+        }
+    ],
+    "src/ch/tf/playingfield/PlayingField.java": [
+        {
+            "kind": "gerritcodereview#comment",
+            "id": "da33351e_41fff201",
+            "message": "looks good to me!",
+            "updated": "2014-05-28 19:14:50.629000000",
+            "author": {
+                "_account_id": 1000000,
+                "name": "Thomas Forrer",
+                "email": "forrert@gmail.com",
+                "username": "forrert",
+                "avatars": []
+            }
+        },
+        {
+            "kind": "gerritcodereview#comment",
+            "id": "da33351e_21046e14",
+            "line": 4,
+            "message": "please reformat imports",
+            "updated": "2014-05-28 19:14:50.629000000",
+            "author": {
+                "_account_id": 1000000,
+                "name": "Thomas Forrer",
+                "email": "forrert@gmail.com",
+                "username": "forrert",
+                "avatars": []
+            }
+        }
+    ]
+}


### PR DESCRIPTION
- split comments parsing in RevisionApiRestClient into separate class
- add unit test for CommentsParser

Note: I am starting to feel a bit weird about instantiating all these parsers in GerritApiImpl and passing them down to the respective REST clients. I think it might be a little nicer to have access to all parsers through a single object that can be passed to all REST clients (maybe a ParserProvider?). Same goes for passing REST clients down to other REST clients. I don't really have an idea right now though about how to fix this. Maybe it's not such a big deal after all... It is certainly a nicer setup to write tests than having static access to these services. What do you think?
