### PR TITLE
implement ChangeApi#suggestReviewers methods

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
@@ -54,8 +54,8 @@ public class GerritApiImpl extends GerritApi.NotImplemented implements GerritApi
                     new ChangesParser(gerritRestClient.getGson()),
                     new CommentsParser(gerritRestClient.getGson()),
                     new FileInfoParser(gerritRestClient.getGson()),
-                    new DiffInfoParser(gerritRestClient.getGson())
-            );
+                    new DiffInfoParser(gerritRestClient.getGson()),
+                    new SuggestedReviewerInfoParser(gerritRestClient.getGson()));
         }
     });
 

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
@@ -38,17 +38,20 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
     private final CommentsParser commentsParser;
     private final FileInfoParser fileInfoParser;
     private final DiffInfoParser diffInfoParser;
+    private final SuggestedReviewerInfoParser suggestedReviewerInfoParser;
 
     public ChangesRestClient(GerritRestClient gerritRestClient,
                              ChangesParser changesParser,
                              CommentsParser commentsParser,
                              FileInfoParser fileInfoParser,
-                             DiffInfoParser diffInfoParser) {
+                             DiffInfoParser diffInfoParser,
+                             SuggestedReviewerInfoParser suggestedReviewerInfoParser) {
         this.gerritRestClient = gerritRestClient;
         this.changesParser = changesParser;
         this.commentsParser = commentsParser;
         this.fileInfoParser = fileInfoParser;
         this.diffInfoParser = diffInfoParser;
+        this.suggestedReviewerInfoParser = suggestedReviewerInfoParser;
     }
 
     @Override
@@ -93,16 +96,16 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
 
     @Override
     public ChangeApi id(int id) throws RestApiException {
-        return new ChangeApiRestClient(gerritRestClient, this, commentsParser, fileInfoParser, diffInfoParser, id);
+        return new ChangeApiRestClient(gerritRestClient, this, commentsParser, fileInfoParser, diffInfoParser, suggestedReviewerInfoParser, id);
     }
 
     @Override
     public ChangeApi id(String triplet) throws RestApiException {
-        return new ChangeApiRestClient(gerritRestClient, this, commentsParser, fileInfoParser, diffInfoParser, triplet);
+        return new ChangeApiRestClient(gerritRestClient, this, commentsParser, fileInfoParser, diffInfoParser, suggestedReviewerInfoParser, triplet);
     }
 
     @Override
     public ChangeApi id(String project, String branch, String id) throws RestApiException {
-        return new ChangeApiRestClient(gerritRestClient, this, commentsParser, fileInfoParser, diffInfoParser, String.format("%s~%s~%s", project, branch, id));
+        return new ChangeApiRestClient(gerritRestClient, this, commentsParser, fileInfoParser, diffInfoParser, suggestedReviewerInfoParser, String.format("%s~%s~%s", project, branch, id));
     }
 }

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/SuggestedReviewerInfoParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/SuggestedReviewerInfoParser.java
@@ -1,0 +1,45 @@
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.common.collect.Lists;
+import com.google.gerrit.extensions.common.SuggestedReviewerInfo;
+import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author Thomas Forrer
+ */
+public class SuggestedReviewerInfoParser {
+    private final Gson gson;
+
+    public SuggestedReviewerInfoParser(Gson gson) {
+        this.gson = gson;
+    }
+
+    public List<SuggestedReviewerInfo> parseSuggestReviewerInfos(JsonElement result) throws RestApiException {
+        if (!result.isJsonArray()) {
+            if (!result.isJsonObject()) {
+                throw new RestApiException(String.format("Unexpected JSON result format: %s", result));
+            }
+            return Collections.singletonList(parseSingleSuggestReviewerInfo(result.getAsJsonObject()));
+        }
+
+        List<SuggestedReviewerInfo> changeInfoList = Lists.newArrayList();
+        for (JsonElement element : result.getAsJsonArray()) {
+            if (!element.isJsonObject()) {
+                throw new RestApiException(String.format("This element should be a JsonObject: %s%nTotal JSON response: %n%s", element, result));
+            }
+            changeInfoList.add(parseSingleSuggestReviewerInfo(element.getAsJsonObject()));
+        }
+        return changeInfoList;
+    }
+
+    public SuggestedReviewerInfo parseSingleSuggestReviewerInfo(JsonObject result) {
+        return gson.fromJson(result, SuggestedReviewerInfo.class);
+    }
+
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
@@ -84,7 +84,7 @@ public class ChangesRestClientTest {
         GerritRestClient gerritRestClient = setupGerritRestClient(testCase);
         ChangesParser changesParser = setupChangesParser();
 
-        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null);
+        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null, null);
 
         Changes.QueryRequest queryRequest = changes.query();
         testCase.queryParameter.apply(queryRequest).get();
@@ -100,7 +100,7 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = setupChangesParser();
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
 
-        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null);
+        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null);
         changesRestClient.query("is:open").get();
 
         EasyMock.verify(gerritRestClient);
@@ -112,7 +112,7 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = EasyMock.createMock(ChangesParser.class);
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
 
-        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null);
+        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null);
 
         ChangeApi changeApi = changesRestClient.id(123);
 
@@ -125,7 +125,7 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = EasyMock.createMock(ChangesParser.class);
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
 
-        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null);
+        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null);
 
         ChangeApi changeApi = changesRestClient.id("packages%2Ftest", "master", "Ieabd72e73f3da0df90fd6e8cba8f6c5dd7d120df");
 
@@ -138,7 +138,7 @@ public class ChangesRestClientTest {
         GerritRestClient gerritRestClient = setupGerritRestClient(testCase);
         ChangesParser changesParser = setupChangesParser();
 
-        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null);
+        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null, null);
 
         changes.query().get();
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
@@ -148,7 +148,7 @@ public class RevisionApiRestClientTest {
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
         FileInfoParser fileInfoParser = EasyMock.createMock(FileInfoParser.class);
         DiffInfoParser diffInfoParser = EasyMock.createMock(DiffInfoParser.class);
-        return new ChangesRestClient(gerritRestClient, changesParser, commentsParser, fileInfoParser, diffInfoParser);
+        return new ChangesRestClient(gerritRestClient, changesParser, commentsParser, fileInfoParser, diffInfoParser, null);
     }
 
     private ChangesRestClient getChangesRestClient(GerritRestClient gerritRestClient, CommentsParser commentsParser) {
@@ -157,7 +157,8 @@ public class RevisionApiRestClientTest {
                 EasyMock.createMock(ChangesParser.class),
                 commentsParser,
                 EasyMock.createMock(FileInfoParser.class),
-                EasyMock.createMock(DiffInfoParser.class));
+                EasyMock.createMock(DiffInfoParser.class),
+                null);
     }
 
     private static RevisionApiTestCase withRevision(String revision) {


### PR DESCRIPTION
I left out a unit test for the new parser class as I'm planning to refactor large parts of the parsing functionality. There is a lot of code duplication there, and I think we can implement it in a much simpler way.
