### PR TITLE
Add BranchInfo and getBranches Method

### DIFF
--- a/src/main/java/com/google/gerrit/extensions/api/projects/ProjectApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/ProjectApi.java
@@ -14,6 +14,9 @@
 
 package com.google.gerrit.extensions.api.projects;
 
+import java.util.List;
+
+import com.google.gerrit.extensions.common.BranchInfo;
 import com.google.gerrit.extensions.common.ProjectInfo;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
@@ -22,6 +25,7 @@ public interface ProjectApi {
   ProjectApi create() throws RestApiException;
   ProjectApi create(ProjectInput in) throws RestApiException;
   ProjectInfo get();
+  List<BranchInfo> getBranches() throws RestApiException;
 
   /**
    * Look up a branch by refname.
@@ -61,5 +65,10 @@ public interface ProjectApi {
     public BranchApi branch(String ref) {
       throw new NotImplementedException();
     }
+
+    @Override
+    public List<BranchInfo> getBranches() throws RestApiException {
+      throw new NotImplementedException();
+    }    
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/BranchInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/BranchInfo.java
@@ -1,0 +1,21 @@
+// Copyright (C) 2014 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+public class BranchInfo {
+	public String ref;
+	public String revision;
+	public Boolean canDelete;
+}

--- a/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
@@ -30,6 +30,7 @@ import com.urswolfer.gerrit.client.rest.http.accounts.AccountsParser;
 import com.urswolfer.gerrit.client.rest.http.accounts.AccountsRestClient;
 import com.urswolfer.gerrit.client.rest.http.changes.*;
 import com.urswolfer.gerrit.client.rest.http.config.ConfigRestClient;
+import com.urswolfer.gerrit.client.rest.http.projects.BranchInfoParser;
 import com.urswolfer.gerrit.client.rest.http.projects.ProjectsParser;
 import com.urswolfer.gerrit.client.rest.http.projects.ProjectsRestClient;
 import com.urswolfer.gerrit.client.rest.http.tools.ToolsRestClient;
@@ -71,7 +72,7 @@ public class GerritApiImpl extends GerritApi.NotImplemented implements GerritRes
     private final Supplier<ProjectsRestClient> projectsRestClient = Suppliers.memoize(new Supplier<ProjectsRestClient>() {
         @Override
         public ProjectsRestClient get() {
-            return new ProjectsRestClient(gerritRestClient, new ProjectsParser(gerritRestClient.getGson()));
+            return new ProjectsRestClient(gerritRestClient, new ProjectsParser(gerritRestClient.getGson()), new BranchInfoParser(gerritRestClient.getGson()));
         }
     });
 

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/projects/BranchInfoParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/projects/BranchInfoParser.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2013-2014 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.gerrit.client.rest.http.projects;
+
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
+import com.google.gerrit.extensions.common.BranchInfo;
+import com.google.gerrit.extensions.common.CommentInfo;
+import com.google.gerrit.extensions.common.DiffInfo;
+import com.google.gerrit.extensions.common.ProjectInfo;
+import com.google.gerrit.extensions.common.SuggestedReviewerInfo;
+import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.TreeMap;
+
+/**
+ * @author Tim Coulson
+ */
+public class BranchInfoParser {
+    private final Gson gson;
+    private static final Type TYPE = new TypeToken<List<BranchInfo>>() {}.getType();
+    public BranchInfoParser(Gson gson) {
+        this.gson = gson;
+    }
+
+    public List<BranchInfo> parseBranchInfos(JsonElement result) {
+        if (!result.isJsonArray()) {
+            return Collections.singletonList(gson.fromJson(result, BranchInfo.class));
+        } 
+        return gson.fromJson(result, TYPE);
+    }
+}

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectApiRestClient.java
@@ -16,9 +16,12 @@
 
 package com.urswolfer.gerrit.client.rest.http.projects;
 
+import java.util.List;
+
 import com.google.common.base.Throwables;
 import com.google.gerrit.extensions.api.projects.ProjectApi;
 import com.google.gerrit.extensions.api.projects.ProjectInput;
+import com.google.gerrit.extensions.common.BranchInfo;
 import com.google.gerrit.extensions.common.ProjectInfo;
 import com.google.gerrit.extensions.restapi.RestApiException;
 import com.google.gson.JsonElement;
@@ -30,13 +33,16 @@ import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
 public class ProjectApiRestClient extends ProjectApi.NotImplemented implements ProjectApi {
     private final GerritRestClient gerritRestClient;
     private final ProjectsParser projectsParser;
+    private final BranchInfoParser branchInfoParser;
     private final String name;
 
     public ProjectApiRestClient(GerritRestClient gerritRestClient,
-                                ProjectsParser projectsParser,
-                                String name) {
+            ProjectsParser projectsParser,
+            BranchInfoParser branchInfoParser,
+            String name) {
         this.gerritRestClient = gerritRestClient;
         this.projectsParser = projectsParser;
+        this.branchInfoParser = branchInfoParser;
         this.name = name;
     }
 
@@ -61,6 +67,12 @@ public class ProjectApiRestClient extends ProjectApi.NotImplemented implements P
         String body = gerritRestClient.getGson().toJson(in);
         gerritRestClient.putRequest(projectsUrl(), body);
         return this;
+    }
+
+    public List<BranchInfo> getBranches() throws RestApiException {
+        String request = projectsUrl() + "/branches";
+        JsonElement branches = gerritRestClient.getRequest(request);
+        return branchInfoParser.parseBranchInfos(branches);
     }
 
     private String projectsUrl() {

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectsRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectsRestClient.java
@@ -35,11 +35,14 @@ public class ProjectsRestClient extends Projects.NotImplemented implements Proje
 
     private final GerritRestClient gerritRestClient;
     private final ProjectsParser projectsParser;
+    private final BranchInfoParser branchInfoParser;
 
     public ProjectsRestClient(GerritRestClient gerritRestClient,
-                              ProjectsParser projectsParser) {
+            ProjectsParser projectsParser,
+            BranchInfoParser branchInfoParser) {
         this.gerritRestClient = gerritRestClient;
         this.projectsParser = projectsParser;
+        this.branchInfoParser = branchInfoParser;
     }
 
     @Override
@@ -54,7 +57,7 @@ public class ProjectsRestClient extends Projects.NotImplemented implements Proje
 
     @Override
     public ProjectApi name(String name) throws RestApiException {
-        return new ProjectApiRestClient(gerritRestClient, projectsParser, name);
+        return new ProjectApiRestClient(gerritRestClient, projectsParser, branchInfoParser, name);
     }
 
     private List<ProjectInfo> list(ListRequest listParameter) throws RestApiException {

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/projects/BranchInfoParserBuilder.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/projects/BranchInfoParserBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2013-2014 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.gerrit.client.rest.http.projects;
+
+import java.util.List;
+
+import com.google.gerrit.extensions.common.BranchInfo;
+import com.google.gerrit.extensions.common.ProjectInfo;
+import com.google.gson.JsonElement;
+
+import org.easymock.EasyMock;
+
+/**
+ * @author Tim Coulson
+ */
+public final class BranchInfoParserBuilder {
+	private final BranchInfoParser branchInfoParser = EasyMock.createMock(BranchInfoParser.class);
+
+	public BranchInfoParser get() {
+		EasyMock.replay(branchInfoParser);
+		return branchInfoParser;
+	}
+
+	public BranchInfoParserBuilder expectParseBranchInfos(JsonElement jsonElement, List<BranchInfo> result) {
+		EasyMock.expect(branchInfoParser.parseBranchInfos(jsonElement))
+		.andReturn(result).once();
+		return this;
+	}
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectApiRestClientTest.java
@@ -16,14 +16,18 @@
 
 package com.urswolfer.gerrit.client.rest.http.projects;
 
+import java.util.List;
+
 import com.google.common.collect.Lists;
 import com.google.common.truth.Truth;
 import com.google.gerrit.extensions.api.projects.ProjectInput;
+import com.google.gerrit.extensions.common.BranchInfo;
 import com.google.gerrit.extensions.common.ProjectInfo;
 import com.google.gerrit.extensions.restapi.RestApiException;
 import com.google.gson.JsonElement;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
 import com.urswolfer.gerrit.client.rest.http.common.GerritRestClientBuilder;
+
 import org.easymock.EasyMock;
 import org.testng.annotations.Test;
 
@@ -34,6 +38,7 @@ public class ProjectApiRestClientTest {
 
     public static final JsonElement MOCK_JSON_ELEMENT = EasyMock.createMock(JsonElement.class);
     public static final ProjectInfo MOCK_PROJECT_INFO = EasyMock.createMock(ProjectInfo.class);
+    public static final List<BranchInfo> BRANCH_INFOS = Lists.newArrayList();
 
     @Test
     public void testGetProjectInfoForName() throws Exception {
@@ -44,7 +49,10 @@ public class ProjectApiRestClientTest {
         ProjectsParser projectsParser = new ProjectsParserBuilder()
                 .expectParseSingleProjectInfo(MOCK_JSON_ELEMENT, MOCK_PROJECT_INFO)
                 .get();
-        ProjectsRestClient projectsRestClient = new ProjectsRestClient(gerritRestClient, projectsParser);
+        BranchInfoParser branchInfoParser = new BranchInfoParserBuilder()
+                .expectParseBranchInfos(MOCK_JSON_ELEMENT,BRANCH_INFOS)
+                 .get();
+        ProjectsRestClient projectsRestClient = new ProjectsRestClient(gerritRestClient, projectsParser, branchInfoParser);
 
         ProjectInfo projectInfo = projectsRestClient.name(projectName).get();
 
@@ -59,7 +67,8 @@ public class ProjectApiRestClientTest {
                 .expectGet("/projects/sandbox", new RestApiException())
                 .get();
         ProjectsParser projectsParser = new ProjectsParserBuilder().get();
-        ProjectsRestClient projectsRestClient = new ProjectsRestClient(gerritRestClient, projectsParser);
+        BranchInfoParser branchInfoParser = new BranchInfoParserBuilder().get();
+        ProjectsRestClient projectsRestClient = new ProjectsRestClient(gerritRestClient, projectsParser, branchInfoParser);
 
         projectsRestClient.name(projectName).get();
     }
@@ -71,7 +80,8 @@ public class ProjectApiRestClientTest {
                 .expectPut("/projects/sandbox", MOCK_JSON_ELEMENT)
                 .get();
         ProjectsParser projectsParser = new ProjectsParserBuilder().get();
-        ProjectsRestClient projectsRestClient = new ProjectsRestClient(gerritRestClient, projectsParser);
+        BranchInfoParser branchInfoParser = new BranchInfoParserBuilder().get();
+        ProjectsRestClient projectsRestClient = new ProjectsRestClient(gerritRestClient, projectsParser, branchInfoParser);
 
         projectsRestClient.name(projectName).create();
 
@@ -99,7 +109,8 @@ public class ProjectApiRestClientTest {
                 .expectGetGson()
                 .get();
         ProjectsParser projectsParser = new ProjectsParserBuilder().get();
-        ProjectsRestClient projectsRestClient = new ProjectsRestClient(gerritRestClient, projectsParser);
+        BranchInfoParser branchInfoParser = new BranchInfoParserBuilder().get();
+        ProjectsRestClient projectsRestClient = new ProjectsRestClient(gerritRestClient, projectsParser, branchInfoParser);
 
         projectsRestClient.name(projectName).create(projectInput);
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectsRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectsRestClientTest.java
@@ -20,9 +20,11 @@ import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.gerrit.extensions.api.projects.Projects;
+import com.google.gerrit.extensions.common.BranchInfo;
 import com.google.gerrit.extensions.common.ProjectInfo;
 import com.google.gson.JsonElement;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+
 import org.easymock.EasyMock;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -88,6 +90,7 @@ public class ProjectsRestClientTest {
         private JsonElement mockJsonElement = EasyMock.createMock(JsonElement.class);
         private GerritRestClient gerritRestClient;
         private ProjectsParser projectsParser;
+        private BranchInfoParser branchInfoParser;
 
         public ProjectListTestCase withListParameter(TestListRequest listParameter) {
             this.listParameter = listParameter;
@@ -113,7 +116,8 @@ public class ProjectsRestClientTest {
         public ProjectsRestClient getProjectsRestClient() throws Exception {
             return new ProjectsRestClient(
                     setupGerritRestClient(),
-                    setupProjectsParser()
+                    setupProjectsParser(),
+                    setupBranchInfoParser()
             );
         }
 
@@ -133,6 +137,15 @@ public class ProjectsRestClientTest {
                     .once();
             EasyMock.replay(projectsParser);
             return projectsParser;
+        }
+        
+        public BranchInfoParser setupBranchInfoParser() throws Exception {
+            branchInfoParser = EasyMock.createMock(BranchInfoParser.class);
+            EasyMock.expect(branchInfoParser.parseBranchInfos(mockJsonElement))
+                    .andReturn(Lists.<BranchInfo>newArrayList())
+                    .once();
+            EasyMock.replay(branchInfoParser);
+            return branchInfoParser;
         }
 
         @Override


### PR DESCRIPTION
Hi Urs,
I've added a getBranches() method to the ProjectApi which will return a list of BranchInfo objects for the queried project. I'm intending on extending this to get all of the branch endpoints, but right now this functionality is very useful for my Gerrit project.
Tim