### PR TITLE
Fixed IOException while trying to convert file base64 content data to json

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/FileApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/FileApiRestClient.java
@@ -56,9 +56,8 @@ public class FileApiRestClient implements FileApi {
     @Override
     public BinaryResult content() throws RestApiException {
         String request = getRequestPath() + "/content";
-        JsonElement jsonElement = gerritRestClient.getRequest(request);
-        String content = jsonElement.getAsString();
-        return BinaryResult.create(content.getBytes()).base64();
+        byte[] content = gerritRestClient.getRequestSimple(request);
+        return BinaryResult.create(content).base64();
     }
 
     @Override

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/FileApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/FileApiRestClientTest.java
@@ -48,10 +48,10 @@ public class FileApiRestClientTest {
     @Test
     public void testContent() throws Exception {
         String requestUrl = getBaseRequestUrl() + "/content";
-        JsonPrimitive jsonElement = new JsonPrimitive(Base64.encodeBase64String(FILE_CONTENT.getBytes("UTF-8")));
+        byte[] possibleResult = Base64.encodeBase64String(FILE_CONTENT.getBytes("UTF-8")).getBytes("UTF-8");
 
         setupServices();
-        GerritRestClient gerritRestClient = new GerritRestClientBuilder().expectGet(requestUrl, jsonElement).get();
+        GerritRestClient gerritRestClient = new GerritRestClientBuilder().expectGet(requestUrl, possibleResult).get();
 
         FileApiRestClient fileApiRestClient = new FileApiRestClient(gerritRestClient, revisionApiRestClient, null, FILE_PATH);
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/GerritRestClientBuilder.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/GerritRestClientBuilder.java
@@ -36,6 +36,11 @@ public final class GerritRestClientBuilder {
         return this;
     }
 
+    public GerritRestClientBuilder expectGet(String url, byte[] result) throws Exception {
+        EasyMock.expect(gerritRestClient.getRequestSimple(url)).andReturn(result).once();
+        return this;
+    }
+
     public GerritRestClientBuilder expectGet(String url, Throwable throwable) throws Exception {
         EasyMock.expect(gerritRestClient.getRequest(url)).andThrow(throwable).once();
         return this;


### PR DESCRIPTION
When trying to fetch file content, you'll always get IOException, because current code always tries to parse base64 server response into json, which is usually impossible.