### PR TITLE
Use java 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jdk.min.version>1.6</jdk.min.version>
+    <jdk.min.version>1.7</jdk.min.version>
     <jetty.version>8.1.18.v20150929</jetty.version> <!-- we need jetty 8 because of java 1.6 compatibility -->
   </properties>
 
@@ -114,8 +114,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Compilation with java 1.6 fails, only 1.7 and above can compile.

See [here](https://jitpack.io/com/github/uwolfer/gerrit-rest-java-client/v0.8.6/build.log) for a failed attempt to build 0.8.6 with java 1.6.

This PR fixes [jitpack](https://jitpack.io/) compilability.

Also, if you merge this PR into master, can you merge master into httpclient-android? it would be cool if that branch could be compiled with jitpack as well.