### PR TITLE
support java 1.6

### DIFF
--- a/src/main/java/com/google/gerrit/extensions/restapi/BinaryResult.java
+++ b/src/main/java/com/google/gerrit/extensions/restapi/BinaryResult.java
@@ -21,8 +21,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.CodingErrorAction;
 import java.nio.charset.UnsupportedCharsetException;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 /**
  * Wrapper around a non-JSON result from a {@link RestView}.
  * <p>
@@ -32,6 +30,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * from a {@code byte[]} or {@code InputSteam}.
  */
 public abstract class BinaryResult implements Closeable {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
   /** Default MIME type for unknown binary data. */
   static final String OCTET_STREAM = "application/octet-stream";
 

--- a/src/main/java/com/google/gerrit/extensions/restapi/Url.java
+++ b/src/main/java/com/google/gerrit/extensions/restapi/Url.java
@@ -17,11 +17,11 @@ package com.google.gerrit.extensions.restapi;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import java.nio.charset.Charset;
 
 /** URL related utility functions. */
 public final class Url {
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
   /**
    * Encode a path segment, escaping characters not valid for a URL.
    * <p>


### PR DESCRIPTION
Current gerrit 0.9.7.5 doesn't support java 1.6, it show as "cannot login", and throws an exception.

And, under Mac OS X, java 1.6 by Apple looks better than 1.7+ by Oracle.