### PR TITLE
Force JSON test resources to have Unix-style LF line endings

### DIFF
--- a/src/test/resources/.gitattributes
+++ b/src/test/resources/.gitattributes
@@ -1,0 +1,1 @@
+*.json	eol=lf


### PR DESCRIPTION
Gson is strict about the Unix line ending when checking for the
non-execute prefix [1], so ensure to have Unix line endings even on e.g.
Windows.

Fixes #35.

[1] https://google.github.io/gson/apidocs/com/google/gson/stream/JsonReader.html#nonexecuteprefix