### PR TITLE
Adding support for Gerrit group operations

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
@@ -21,6 +21,7 @@ import com.google.common.base.Suppliers;
 import com.google.gerrit.extensions.api.GerritApi;
 import com.google.gerrit.extensions.api.changes.Changes;
 import com.google.gerrit.extensions.api.config.Config;
+import com.google.gerrit.extensions.api.groups.Groups;
 import com.google.gerrit.extensions.api.projects.Projects;
 import com.urswolfer.gerrit.client.rest.accounts.Accounts;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
@@ -30,6 +31,8 @@ import com.urswolfer.gerrit.client.rest.http.accounts.AccountsParser;
 import com.urswolfer.gerrit.client.rest.http.accounts.AccountsRestClient;
 import com.urswolfer.gerrit.client.rest.http.changes.*;
 import com.urswolfer.gerrit.client.rest.http.config.ConfigRestClient;
+import com.urswolfer.gerrit.client.rest.http.groups.GroupsParser;
+import com.urswolfer.gerrit.client.rest.http.groups.GroupsRestClient;
 import com.urswolfer.gerrit.client.rest.http.projects.BranchInfoParser;
 import com.urswolfer.gerrit.client.rest.http.projects.ProjectsParser;
 import com.urswolfer.gerrit.client.rest.http.projects.ProjectsRestClient;
@@ -42,6 +45,13 @@ import com.urswolfer.gerrit.client.rest.tools.Tools;
  */
 public class GerritApiImpl extends GerritApi.NotImplemented implements GerritRestApi {
     private final GerritRestClient gerritRestClient;
+
+    private final Supplier<GroupsRestClient> groupsRestClient = Suppliers.memoize(new Supplier<GroupsRestClient>() {
+        @Override
+        public GroupsRestClient get() {
+            return new GroupsRestClient(gerritRestClient, new GroupsParser(gerritRestClient.getGson()));
+        }
+    });
 
     private final Supplier<AccountsRestClient> accountsRestClient = Suppliers.memoize(new Supplier<AccountsRestClient>() {
         @Override
@@ -107,6 +117,11 @@ public class GerritApiImpl extends GerritApi.NotImplemented implements GerritRes
     @Override
     public Config config() {
         return configRestClient.get();
+    }
+
+    @Override
+    public Groups groups() {
+        return groupsRestClient.get();
     }
 
     @Override

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupApiRestClient.java
@@ -1,0 +1,195 @@
+package com.urswolfer.gerrit.client.rest.http.groups;
+
+import com.google.gerrit.extensions.api.groups.GroupApi;
+import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.GroupAuditEventInfo;
+import com.google.gerrit.extensions.common.GroupInfo;
+import com.google.gerrit.extensions.common.GroupOptionsInfo;
+import com.google.gerrit.extensions.restapi.BinaryResult;
+import com.google.gerrit.extensions.restapi.NotImplementedException;
+import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gerrit.extensions.restapi.Url;
+import com.google.gson.JsonElement;
+import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import com.urswolfer.gerrit.client.rest.http.util.BinaryResultUtils;
+import org.apache.http.HttpResponse;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+
+
+/**
+ * Extend the Gerrit implementation in order to add custom functionality
+ * that is not currently supported in the API.
+ *
+ * @author Shawn Stafford
+ */
+public class GroupApiRestClient implements GroupApi {
+
+    /** Base REST URL for managing Group data */
+    private static final String BASE_URL = "/groups";
+
+
+    private final GroupsParser groupsParser;
+
+    private final GerritRestClient gerritRestClient;
+    private final String groupId;
+
+    public GroupApiRestClient(
+        GerritRestClient gerritRestClient,
+        GroupsParser groupsParser,
+        String id)
+    {
+        this.gerritRestClient = gerritRestClient;
+        this.groupsParser = groupsParser;
+        this.groupId = id;
+    }
+
+    public static String getBaseRequestPath() {
+        return BASE_URL;
+    }
+
+    public static String getRequestPath(String id) {
+        return BASE_URL + "/" + id;
+    }
+
+    protected String getRequestPath() {
+        return getRequestPath(groupId);
+    }
+
+    @Override
+    public GroupInfo get() throws RestApiException {
+        String restPath = getRequestPath();
+        JsonElement result = gerritRestClient.getRequest(restPath);
+        return groupsParser.parseGroupInfo(result);
+    }
+
+    @Override
+    public GroupInfo detail() throws RestApiException {
+        String restPath = getRequestPath() + "/detail";
+        JsonElement result = gerritRestClient.getRequest(restPath);
+        return groupsParser.parseGroupInfo(result);
+    }
+
+    @Override
+    public String name() throws RestApiException {
+        String restPath = getRequestPath() + "/name";
+        return gerritRestClient.getRequest(restPath).getAsString();
+    }
+
+    @Override
+    public void name(String name) throws RestApiException {
+        String restPath = getRequestPath() + "/name";
+        gerritRestClient.putRequest(restPath, name);
+    }
+
+    @Override
+    public GroupInfo owner() throws RestApiException {
+        String restPath = getRequestPath() + "/owner";
+        JsonElement result = gerritRestClient.getRequest(restPath);
+        return groupsParser.parseGroupInfo(result);
+    }
+
+    @Override
+    public void owner(String owner) throws RestApiException {
+        String restPath = getRequestPath() + "/owner";
+        gerritRestClient.putRequest(restPath, owner);
+    }
+
+    @Override
+    public String description() throws RestApiException {
+        String restPath = getRequestPath() + "/description";
+        return gerritRestClient.getRequest(restPath).getAsString();
+    }
+
+    @Override
+    public void description(String description) throws RestApiException {
+        String restPath = getRequestPath() + "/description";
+        gerritRestClient.putRequest(restPath, description);
+    }
+
+    @Override
+    public GroupOptionsInfo options() throws RestApiException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void options(GroupOptionsInfo options) throws RestApiException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public List<AccountInfo> members() throws RestApiException {
+        return members(false);
+    }
+
+    @Override
+    public List<AccountInfo> members(boolean recursive) throws RestApiException {
+        String restPath = null;
+        if (recursive) {
+            restPath = getRequestPath() + "/members/?recursive";
+        } else {
+            restPath = getRequestPath() + "/members";
+        }
+        JsonElement result = gerritRestClient.getRequest(restPath);
+        return groupsParser.parseGroupMembers(result);
+    }
+
+    @Override
+    public void addMembers(String... members) throws RestApiException {
+        String restPath = getRequestPath() + "/members";
+
+        // Create an object which can be used to create the json for:
+        // { members: [ "member1", "member2" ] }
+        Map<String, List<String>> memberMap = new HashMap<String, List<String>>();
+        memberMap.put("members", Arrays.asList(members));
+        String json = gerritRestClient.getGson().toJson(memberMap);
+
+        JsonElement result = gerritRestClient.postRequest(restPath, json);
+    }
+
+    @Override
+    public void removeMembers(String... members) throws RestApiException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public List<GroupInfo> includedGroups() throws RestApiException {
+        String restPath = getRequestPath() + "/groups/";
+        JsonElement result = gerritRestClient.getRequest(restPath);
+        return groupsParser.parseGroupInfos(result);
+    }
+
+    @Override
+    public void addGroups(String... groups) throws RestApiException {
+        String restPath = getRequestPath() + "/groups";
+
+        // Create an object which can be used to create the json for:
+        // { groups: [ "group1", "group2 ] }
+        Map<String, List<String>> groupMap = new HashMap<String, List<String>>();
+        groupMap.put("groups", Arrays.asList(groups));
+        String json = gerritRestClient.getGson().toJson(groupMap);
+
+        gerritRestClient.postRequest(restPath, json);
+    }
+
+    @Override
+    public void removeGroups(String... groups) throws RestApiException {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public List<? extends GroupAuditEventInfo> auditLog() throws RestApiException {
+        throw new NotImplementedException();
+    }
+
+}

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsParser.java
@@ -1,0 +1,57 @@
+package com.urswolfer.gerrit.client.rest.http.groups;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.GroupInfo;
+import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Extend the Gerrit implementation in order to add custom functionality
+ * that is not currently supported in the API.
+ *
+ * @author Shawn Stafford
+ */
+public class GroupsParser {
+    private static final Type GROUP_MAP_TYPE = new TypeToken<SortedMap<String, GroupInfo>>() {}.getType();
+    private static final Type ACCOUNT_LIST_TYPE = new TypeToken<List<AccountInfo>>() {}.getType();
+
+    private final Gson gson;
+
+    public GroupsParser(Gson gson) {
+        this.gson = gson;
+    }
+
+    public GroupInfo parseGroupInfo(JsonElement result) throws RestApiException {
+        return gson.fromJson(result, GroupInfo.class);
+    }
+
+    public AccountInfo parseGroupMember(JsonElement result) throws RestApiException {
+        return gson.fromJson(result, AccountInfo.class);
+    }
+
+    public List<GroupInfo> parseGroupInfos(JsonElement result) throws RestApiException {
+        SortedMap<String, GroupInfo> map = gson.fromJson(result, GROUP_MAP_TYPE);
+        return new ArrayList(map.values());
+    }
+
+    public List<AccountInfo> parseGroupMembers(JsonElement result) throws RestApiException {
+        List<AccountInfo> list = null;
+        if (!result.isJsonArray()) {
+            // Put the single element in a list
+            list = Collections.singletonList(parseGroupMember(result));
+        } else {
+            list = gson.fromJson(result, ACCOUNT_LIST_TYPE);
+        }
+        return list;
+    }
+
+}

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsRestClient.java
@@ -1,0 +1,152 @@
+package com.urswolfer.gerrit.client.rest.http.groups;
+
+import com.google.common.base.Strings;
+import com.google.gerrit.extensions.common.GroupInfo;
+import com.google.gerrit.extensions.api.groups.GroupApi;
+import com.google.gerrit.extensions.api.groups.GroupInput;
+import com.google.gerrit.extensions.api.groups.Groups;
+import com.google.gerrit.extensions.restapi.NotImplementedException;
+import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gerrit.extensions.restapi.Url;
+import com.google.gson.JsonElement;
+import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import com.urswolfer.gerrit.client.rest.http.util.UrlUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * Extend the Gerrit implementation in order to add custom functionality
+ * that is not currently supported in the API.
+ *
+ * @author Shawn Stafford
+ */
+public class GroupsRestClient implements Groups {
+
+    private final GerritRestClient gerritRestClient;
+    private final GroupsParser groupsParser;
+
+    public GroupsRestClient(GerritRestClient gerritRestClient, GroupsParser groupsParser) {
+        this.gerritRestClient = gerritRestClient;
+        this.groupsParser = groupsParser;
+    }
+
+    private String getRequestPath() {
+        return "/groups";
+    }
+
+    /**
+     * Look up a group by ID.
+     * <p>
+     * <strong>Note:</strong> This method eagerly reads the group. Methods that
+     * mutate the group do not necessarily re-read the group. Therefore, calling a
+     * getter method on an instance after calling a mutation method on that same
+     * instance is not guaranteed to reflect the mutation. It is not recommended
+     * to store references to {@code groupApi} instances.
+     *
+     * @param id any identifier supported by the REST API, including group name or
+     *     UUID.
+     * @return API for accessing the group.
+     * @throws RestApiException if an error occurred.
+     */
+    public GroupApi id(String id) throws RestApiException {
+        return new GroupApiRestClient(gerritRestClient, groupsParser, id);
+    }
+
+    /** Create a new group with the given name and default options. */
+    public GroupApi create(String name) throws RestApiException {
+        String restPath = GroupApiRestClient.getBaseRequestPath() + "/" + name;
+        JsonElement result = gerritRestClient.putRequest(restPath);
+        GroupInfo info = groupsParser.parseGroupInfo(result);
+        return new GroupApiRestClient(gerritRestClient, groupsParser, info.id);
+    }
+
+    /** Create a new group. */
+    public GroupApi create(GroupInput input) throws RestApiException {
+        String restPath = GroupApiRestClient.getBaseRequestPath() + "/" + input.name;
+        String body = gerritRestClient.getGson().toJson(input);
+        JsonElement result = gerritRestClient.putRequest(restPath, body);
+        GroupInfo info = groupsParser.parseGroupInfo(result);
+        return new GroupApiRestClient(gerritRestClient, groupsParser, info.id);
+    }
+
+    /** @return new request for listing groups. */
+    public ListRequest list() {
+        return new ListRequest() {
+            @Override
+            public SortedMap<String, GroupInfo> getAsMap() throws RestApiException {
+                SortedMap<String, GroupInfo> map = new TreeMap<String, GroupInfo>();
+                List<GroupInfo> list = GroupsRestClient.this.list(this);
+                if (list != null) {
+                    Iterator listIter = list.iterator();
+                    while (listIter.hasNext()) {
+                        GroupInfo group = (GroupInfo) listIter.next();
+                        map.put(group.id, group);
+                    }
+                }
+                return map;
+            }
+        };
+    }
+
+    private List<GroupInfo> list(ListRequest listParameter) throws RestApiException {
+        List<GroupInfo> list = null;
+
+        // Construct the query parameters
+        String query = "";
+        if (listParameter.getLimit() > 0) {
+            query = UrlUtils.appendToUrlQuery(query, "n=" + listParameter.getLimit());
+        }
+        if (listParameter.getStart() > 0) {
+            query = UrlUtils.appendToUrlQuery(query, "S=" + listParameter.getLimit());
+        }
+        if (listParameter.getOwned()) {
+            query = UrlUtils.appendToUrlQuery(query, "owned");
+        }
+        if ((listParameter.getSuggest() != null) && (listParameter.getSuggest().length() > 0)) {
+            // 1. If this option is set and n is not set, then n defaults to 10
+            // 2. When using this option, the project or p option can be used to
+            //    name the current project, to allow context-dependent suggestions
+            // 3. Not compatible with visible-to-all, owned, user, match, q, or S
+            query = UrlUtils.appendToUrlQuery(query, "suggest=" + listParameter.getSuggest());
+        }
+
+        // TODO if (listParameter.getVisibleToAll()) {}
+        // Not sure how to handle the visible-to-all parameter, or even how to
+        // determine whether to throw a NotImplementedException
+
+        // TODO Implement the other query parameters supported by Groups.ListRequest
+        if ((listParameter.getOptions() != null) && (listParameter.getOptions().size() > 0)) {
+            throw new NotImplementedException();
+        }
+        if ((listParameter.getProjects() != null) && (listParameter.getProjects().size() > 0)) {
+            throw new NotImplementedException();
+        }
+        if ((listParameter.getGroups() != null) && (listParameter.getGroups().size() > 0)) {
+            throw new NotImplementedException();
+        }
+        if (listParameter.getUser() != null) {
+            throw new NotImplementedException();
+        }
+        if (listParameter.getSubstring() != null) {
+            throw new NotImplementedException();
+        }
+
+        String url = GroupApiRestClient.getBaseRequestPath() + "/";
+        if (!Strings.isNullOrEmpty(query)) {
+            url += '?' + query;
+        }
+        JsonElement result = gerritRestClient.getRequest(url);
+        if (result == null) {
+            list = Collections.emptyList();
+        } else {
+            list = groupsParser.parseGroupInfos(result);
+        }
+
+        return list;
+    }
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/GerritAssert.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/GerritAssert.java
@@ -59,6 +59,10 @@ public class GerritAssert {
         assertXmlOutputEqual(actual, expected);
     }
 
+    public static void assertEquals(GroupInfo actual, GroupInfo expected) {
+        assertXmlOutputEqual(actual, expected);
+    }
+
     public static void assertEquals(TreeMap<String, List<CommentInfo>> actual, TreeMap<String, List<CommentInfo>> expected) {
         assertXmlOutputEqual(actual, expected);
     }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/groups/GroupApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/groups/GroupApiRestClientTest.java
@@ -1,0 +1,16 @@
+package com.urswolfer.gerrit.client.rest.http.groups;
+
+import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import org.easymock.EasyMock;
+
+/**
+ * @author Shawn Stafford
+ */
+public class GroupApiRestClientTest {
+
+    private GroupsRestClient getGroupsRestClient(GerritRestClient gerritRestClient) {
+        GroupsParser groupsParser = EasyMock.createMock(GroupsParser.class);
+        return new GroupsRestClient(gerritRestClient, groupsParser);
+    }
+
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsParserTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsParserTest.java
@@ -1,0 +1,57 @@
+package com.urswolfer.gerrit.client.rest.http.groups;
+
+import com.google.common.truth.Truth;
+import com.google.gerrit.extensions.common.GroupInfo;
+import com.google.gerrit.extensions.common.GroupOptionsInfo;
+import com.google.gson.JsonElement;
+import com.urswolfer.gerrit.client.rest.http.common.AbstractParserTest;
+import com.urswolfer.gerrit.client.rest.http.common.GerritAssert;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * @author Shawn Stafford
+ */
+public class GroupsParserTest extends AbstractParserTest {
+    private final GroupsParser groupsParser = new GroupsParser(getGson());
+
+    private final GroupInfo testGroup;
+
+    public GroupsParserTest() {
+        testGroup = new GroupInfo();
+        testGroup.id = "6a1e70e1a88782771a91808c8af9bbb7a9871389";
+        testGroup.name = "Administrators";
+        testGroup.url = "#/admin/groups/uuid-6a1e70e1a88782771a91808c8af9bbb7a9871389";
+        testGroup.description = "Gerrit Site Administrators";
+        testGroup.groupId = new Integer(1);
+        testGroup.owner = "Administrators";
+        testGroup.ownerId = "6a1e70e1a88782771a91808c8af9bbb7a9871389";
+
+        testGroup.options = new GroupOptionsInfo();
+    }
+
+    @Test
+    public void testParseGroupInfo() throws Exception {
+        JsonElement jsonElement = getJsonElement("group.json");
+
+        GroupInfo groupInfo = groupsParser.parseGroupInfo(jsonElement);
+
+        GerritAssert.assertEquals(groupInfo, testGroup);
+    }
+
+    @Test
+    public void testParseGroupInfoWithNullJsonElement() throws Exception {
+        GroupInfo groupInfo = groupsParser.parseGroupInfo(null);
+
+        Truth.assertThat(groupInfo).isNull();
+    }
+
+    @Test
+    public void testParseGroupInfos() throws Exception {
+        JsonElement jsonElement = getJsonElement("groups.json");
+        List<GroupInfo> groupInfos = groupsParser.parseGroupInfos(jsonElement);
+        Truth.assertThat(groupInfos).hasSize(6);
+    }
+
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsRestClientTest.java
@@ -1,0 +1,41 @@
+package com.urswolfer.gerrit.client.rest.http.groups;
+
+import com.google.gerrit.extensions.common.GroupInfo;
+import com.google.gson.JsonElement;
+import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import org.easymock.EasyMock;
+import org.testng.annotations.Test;
+
+/**
+ * @author Shawn Stafford
+ */
+public class GroupsRestClientTest {
+    private static final JsonElement MOCK_JSON_ELEMENT = EasyMock.createMock(JsonElement.class);
+    private static final GroupInfo MOCK_GROUP_INFO = EasyMock.createMock(GroupInfo.class);
+
+    @Test
+    public void testId() throws Exception {
+        GerritRestClient gerritRestClient = gerritRestClientExpectGet("/groups/jdoe");
+        GroupsParser groupsParser = getGroupsParser();
+        GroupsRestClient groupsRestClient = new GroupsRestClient(gerritRestClient, groupsParser);
+        groupsRestClient.id("jdoe").get();
+
+        EasyMock.verify(gerritRestClient, groupsParser);
+    }
+
+    private GerritRestClient gerritRestClientExpectGet(String expectedUrl) throws Exception {
+        GerritRestClient gerritRestClient = EasyMock.createMock(GerritRestClient.class);
+        EasyMock.expect(gerritRestClient.getRequest(expectedUrl))
+            .andReturn(MOCK_JSON_ELEMENT).once();
+        EasyMock.replay(gerritRestClient);
+        return gerritRestClient;
+    }
+
+    private GroupsParser getGroupsParser() throws Exception {
+        GroupsParser groupsParser = EasyMock.createMock(GroupsParser.class);
+        EasyMock.expect(groupsParser.parseGroupInfo(MOCK_JSON_ELEMENT))
+                .andReturn(MOCK_GROUP_INFO).once();
+        EasyMock.replay(groupsParser);
+        return groupsParser;
+    }
+}

--- a/src/test/resources/com/urswolfer/gerrit/client/rest/http/groups/group.json
+++ b/src/test/resources/com/urswolfer/gerrit/client/rest/http/groups/group.json
@@ -1,0 +1,12 @@
+)]}'
+{
+  "id": "6a1e70e1a88782771a91808c8af9bbb7a9871389",
+  "name": "Administrators",
+  "url": "#/admin/groups/uuid-6a1e70e1a88782771a91808c8af9bbb7a9871389",
+  "options": {
+  },
+  "description": "Gerrit Site Administrators",
+  "group_id": 1,
+  "owner": "Administrators",
+  "owner_id": "6a1e70e1a88782771a91808c8af9bbb7a9871389"
+}

--- a/src/test/resources/com/urswolfer/gerrit/client/rest/http/groups/groups.json
+++ b/src/test/resources/com/urswolfer/gerrit/client/rest/http/groups/groups.json
@@ -1,0 +1,63 @@
+)]}'
+{
+  "Administrators": {
+    "id": "6a1e70e1a88782771a91808c8af9bbb7a9871389",
+    "url": "#/admin/groups/uuid-6a1e70e1a88782771a91808c8af9bbb7a9871389",
+    "options": {
+    },
+    "description": "Gerrit Site Administrators",
+    "group_id": 1,
+    "owner": "Administrators",
+    "owner_id": "6a1e70e1a88782771a91808c8af9bbb7a9871389"
+  },
+  "Anonymous Users": {
+    "id": "global%3AAnonymous-Users",
+    "url": "#/admin/groups/uuid-global%3AAnonymous-Users",
+    "options": {
+    },
+    "description": "Any user, signed-in or not",
+    "group_id": 2,
+    "owner": "Administrators",
+    "owner_id": "6a1e70e1a88782771a91808c8af9bbb7a9871389"
+  },
+  "MyProject_Committers": {
+    "id": "834ec36dd5e0ed21a2ff5d7e2255da082d63bbd7",
+    "url": "#/admin/groups/uuid-834ec36dd5e0ed21a2ff5d7e2255da082d63bbd7",
+    "options": {
+      "visible_to_all": true
+    },
+    "group_id": 6,
+    "owner": "MyProject_Committers",
+    "owner_id": "834ec36dd5e0ed21a2ff5d7e2255da082d63bbd7"
+  },
+  "Non-Interactive Users": {
+    "id": "5057f3cbd3519d6ab69364429a89ffdffba50f73",
+    "url": "#/admin/groups/uuid-5057f3cbd3519d6ab69364429a89ffdffba50f73",
+    "options": {
+    },
+    "description": "Users who perform batch actions on Gerrit",
+    "group_id": 4,
+    "owner": "Administrators",
+    "owner_id": "6a1e70e1a88782771a91808c8af9bbb7a9871389"
+  },
+  "Project Owners": {
+    "id": "global%3AProject-Owners",
+    "url": "#/admin/groups/uuid-global%3AProject-Owners",
+    "options": {
+    },
+    "description": "Any owner of the project",
+    "group_id": 5,
+    "owner": "Administrators",
+    "owner_id": "6a1e70e1a88782771a91808c8af9bbb7a9871389"
+  },
+  "Registered Users": {
+    "id": "global%3ARegistered-Users",
+    "url": "#/admin/groups/uuid-global%3ARegistered-Users",
+    "options": {
+    },
+    "description": "Any signed-in user",
+    "group_id": 3,
+    "owner": "Administrators",
+    "owner_id": "6a1e70e1a88782771a91808c8af9bbb7a9871389"
+  }
+}


### PR DESCRIPTION
I have a need to perform operations on Gerrit groups, but there is currently no support in the API.  I've implemented support for many of the operations defined in the GroupAPI.  One thing I wasn't able to get working is support for parsing the "visibile_to_all" option.  You'll see this as a failing unit test, so hopefully someone knows how to correctly parse the project options.  (see ./src/test/resources/com/urswolfer/gerrit/client/rest/http/groups/groups.json for an example of the "visible_to_all" option)