### PR TITLE
URLEncode the Group ID to handle cases where the ID contains spaces

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupApiRestClient.java
@@ -20,6 +20,7 @@ import com.google.gerrit.extensions.api.groups.GroupApi;
 import com.google.gerrit.extensions.common.AccountInfo;
 import com.google.gerrit.extensions.common.GroupInfo;
 import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gerrit.extensions.restapi.Url;
 import com.google.gson.JsonElement;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
 
@@ -55,7 +56,7 @@ public class GroupApiRestClient extends GroupApi.NotImplemented implements Group
     }
 
     public static String getRequestPath(String id) {
-        return BASE_URL + "/" + id;
+        return BASE_URL + "/" + Url.encode(id);
     }
 
     protected String getRequestPath() {

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsRestClient.java
@@ -23,6 +23,7 @@ import com.google.gerrit.extensions.api.groups.Groups;
 import com.google.gerrit.extensions.common.GroupInfo;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gerrit.extensions.restapi.Url;
 import com.google.gson.JsonElement;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
 import com.urswolfer.gerrit.client.rest.http.util.UrlUtils;
@@ -59,7 +60,7 @@ public class GroupsRestClient extends Groups.NotImplemented implements Groups {
 
     @Override
     public GroupApi create(GroupInput input) throws RestApiException {
-        String restPath = GroupApiRestClient.getBaseRequestPath() + "/" + input.name;
+        String restPath = GroupApiRestClient.getBaseRequestPath() + "/" + Url.encode(input.name);
         String body = gerritRestClient.getGson().toJson(input);
         JsonElement result = gerritRestClient.putRequest(restPath, body);
         GroupInfo info = groupsParser.parseGroupInfo(result);

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectsRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectsRestClient.java
@@ -22,6 +22,7 @@ import com.google.gerrit.extensions.api.projects.ProjectInput;
 import com.google.gerrit.extensions.api.projects.Projects;
 import com.google.gerrit.extensions.common.ProjectInfo;
 import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gerrit.extensions.restapi.Url;
 import com.google.gson.JsonElement;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
 import com.urswolfer.gerrit.client.rest.http.util.UrlUtils;
@@ -105,7 +106,7 @@ public class ProjectsRestClient extends Projects.NotImplemented implements Proje
             throw new IllegalArgumentException("Name must be set in project creation input.");
         }
 
-        String url = String.format("/projects/%s", in.name);
+        String url = String.format("/projects/%s", Url.encode(in.name));
         String projectInput = projectsParser.generateProjectInput(in);
         JsonElement result = gerritRestClient.putRequest(url, projectInput);
         ProjectInfo info = projectsParser.parseSingleProjectInfo(result);


### PR DESCRIPTION
Any Group IDs which contain spaces (or other characters which require URL encoding) are currently failing when the Gerrit REST API calls are made.  To resolve this, the ID needs to be URL encoded prior to submitting the request.