### PR TITLE
Support Gerrit Verify Status REST endpoints

### DIFF
--- a/src/main/java/com/google/gerrit/extensions/api/changes/RevisionApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/RevisionApi.java
@@ -32,6 +32,8 @@ public interface RevisionApi {
   void delete() throws RestApiException;
 
   void review(ReviewInput in) throws RestApiException;
+  // for verify-status-reporter plugin
+  VerifyStatusApi verifyStatus() throws RestApiException;
 
   void submit() throws RestApiException;
   void submit(SubmitInput in) throws RestApiException;
@@ -83,6 +85,12 @@ public interface RevisionApi {
 
     @Override
     public void review(ReviewInput in) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    // for verify-status-reporter plugin
+    @Override
+    public VerifyStatusApi verifyStatus() throws RestApiException {
       throw new NotImplementedException();
     }
 

--- a/src/main/java/com/google/gerrit/extensions/api/changes/VerifyInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/VerifyInput.java
@@ -1,0 +1,25 @@
+// Copyright (C) 2015 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+import com.google.gerrit.extensions.common.VerificationInfo;
+import com.google.gerrit.extensions.restapi.DefaultInput;
+
+import java.util.Map;
+
+public class VerifyInput {
+  @DefaultInput
+  public Map<String, VerificationInfo> verifications;
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/VerifyStatusApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/VerifyStatusApi.java
@@ -1,0 +1,39 @@
+// Copyright (C) 2016 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+import com.google.gerrit.extensions.restapi.NotImplementedException;
+import com.google.gerrit.extensions.restapi.RestApiException;
+
+/**
+ * Support for the REST endpoints provided by the Gerrit Verify Status plugin
+ * @author zaro0508
+ *
+ */
+public interface VerifyStatusApi {
+  void verifications(VerifyInput verifyInput) throws RestApiException;
+
+
+  /**
+   * A default implementation which allows source compatibility
+   * when adding new methods to the interface.
+   **/
+  public class NotImplemented implements VerifyStatusApi {
+    @Override
+    public void verifications(VerifyInput verifyInput) throws RestApiException {
+      throw new NotImplementedException();
+    }
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/VerificationInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/VerificationInfo.java
@@ -1,0 +1,30 @@
+// Copyright (C) 2015 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.sql.Timestamp;
+
+public class VerificationInfo {
+  public String name;
+  public String url;
+  public Short value;
+  public boolean abstain;
+  public boolean rerun;
+  public String reporter;
+  public String comment;
+  public Timestamp granted;
+  public String category;
+  public String duration;
+}

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClient.java
@@ -78,6 +78,11 @@ public class RevisionApiRestClient extends RevisionApi.NotImplemented implements
         gerritRestClient.postRequest(request, json);
     }
 
+    // for verify-status-reporter plugin
+    public VerifyStatusApi verifyStatus() throws RestApiException {
+        return new VerifyStatusApiRestClient(gerritRestClient, this);
+    }
+
     @Override
     public void submit() throws RestApiException {
         submit(new SubmitInput());

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/VerifyStatusApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/VerifyStatusApiRestClient.java
@@ -1,0 +1,40 @@
+// Copyright (C) 2016 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.gerrit.extensions.api.changes.*;
+import com.google.gerrit.extensions.restapi.RestApiException;
+import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+
+public class VerifyStatusApiRestClient extends VerifyStatusApi.NotImplemented
+    implements VerifyStatusApi {
+
+  private final GerritRestClient gerritRestClient;
+  private final RevisionApiRestClient revisionApiRestClient;
+
+  public VerifyStatusApiRestClient(GerritRestClient gerritRestClient,
+      RevisionApiRestClient revisionApiRestClient) {
+    this.gerritRestClient = gerritRestClient;
+    this.revisionApiRestClient = revisionApiRestClient;
+  }
+
+  @Override
+  public void verifications(VerifyInput verifyInput) throws RestApiException {
+    String request =
+        revisionApiRestClient.getRequestPath() + "/verify-status~verifications";
+    String json = gerritRestClient.getGson().toJson(verifyInput);
+    gerritRestClient.postRequest(request, json);
+  }
+}


### PR DESCRIPTION
The gerrit-verify-status plugin provides additional Gerrit REST
endpoints. This adds support for those endpoints[1].

This resolves issue #59

[1] https://gerrit.googlesource.com/plugins/verify-status/+/master/src/main/resources/Documentation/rest-api-changes.md
