### PR TITLE
Conveniently encode the query string like the Gerrit web UI does

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
           <instrumentation>
             <excludes>
               <exclude>com/google/gerrit/extensions/**/*.class</exclude>
+              <exclude>com/google/gwtorm/**/*.class</exclude>
             </excludes>
           </instrumentation>
           <formats>

--- a/src/main/java/com/google/gerrit/extensions/api/changes/Changes.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/Changes.java
@@ -19,6 +19,7 @@ import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.ChangeInput;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gwtorm.server.StandardKeyEncoder;
 
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -75,6 +76,11 @@ public interface Changes {
 
     public QueryRequest withQuery(String query) {
       this.query = query;
+      return this;
+    }
+
+    public QueryRequest encode() {
+      query = StandardKeyEncoder.encode(query);
       return this;
     }
 

--- a/src/main/java/com/google/gwtorm/server/StandardKeyEncoder.java
+++ b/src/main/java/com/google/gwtorm/server/StandardKeyEncoder.java
@@ -1,0 +1,118 @@
+// Copyright 2008 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gwtorm.server;
+
+import com.google.gwtorm.client.KeyUtil.Encoder;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+
+public class StandardKeyEncoder extends Encoder {
+  private static final char[] hexc =
+      {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
+          'E', 'F'};
+  private static final char safe[];
+  private static final byte hexb[];
+
+  static {
+    safe = new char[256];
+    safe['-'] = '-';
+    safe['_'] = '_';
+    safe['.'] = '.';
+    safe['!'] = '!';
+    safe['~'] = '~';
+    safe['*'] = '*';
+    safe['\''] = '\'';
+    safe['('] = '(';
+    safe[')'] = ')';
+    safe['/'] = '/';
+    safe[' '] = '+';
+    for (char c = '0'; c <= '9'; c++)
+      safe[c] = c;
+    for (char c = 'A'; c <= 'Z'; c++)
+      safe[c] = c;
+    for (char c = 'a'; c <= 'z'; c++)
+      safe[c] = c;
+
+    hexb = new byte['f' + 1];
+    Arrays.fill(hexb, (byte) -1);
+    for (char i = '0'; i <= '9'; i++)
+      hexb[i] = (byte) (i - '0');
+    for (char i = 'A'; i <= 'F'; i++)
+      hexb[i] = (byte) ((i - 'A') + 10);
+    for (char i = 'a'; i <= 'f'; i++)
+      hexb[i] = (byte) ((i - 'a') + 10);
+  }
+
+  @Override
+  public String encode(final String e) {
+    final byte[] b;
+    try {
+      b = e.getBytes("UTF-8");
+    } catch (UnsupportedEncodingException e1) {
+      throw new RuntimeException("No UTF-8 support", e1);
+    }
+
+    final StringBuilder r = new StringBuilder(b.length);
+    for (int i = 0; i < b.length; i++) {
+      final int c = b[i] & 0xff;
+      final char s = safe[c];
+      if (s == 0) {
+        r.append('%');
+        r.append(hexc[c >> 4]);
+        r.append(hexc[c & 15]);
+      } else {
+        r.append(s);
+      }
+    }
+    return r.toString();
+  }
+
+  @Override
+  public String decode(final String e) {
+    if (e.indexOf('%') < 0) {
+      return e.replace('+', ' ');
+    }
+
+    final byte[] b = new byte[e.length()];
+    int bPtr = 0;
+    try {
+      for (int i = 0; i < e.length();) {
+        final char c = e.charAt(i);
+        if (c == '%' && i + 2 < e.length()) {
+          final int v = (hexb[e.charAt(i + 1)] << 4) | hexb[e.charAt(i + 2)];
+          if (v < 0) {
+            throw new IllegalArgumentException(e.substring(i, i + 3));
+          }
+          b[bPtr++] = (byte) v;
+          i += 3;
+        } else if (c == '+') {
+          b[bPtr++] = ' ';
+          i++;
+        } else {
+          b[bPtr++] = (byte) c;
+          i++;
+        }
+      }
+    } catch (ArrayIndexOutOfBoundsException err) {
+      throw new IllegalArgumentException("Bad encoding: " + e);
+    }
+    try {
+      return new String(b, 0, bPtr, "UTF-8");
+    } catch (UnsupportedEncodingException e1) {
+      throw new RuntimeException("No UTF-8 support", e1);
+    }
+  }
+}

--- a/src/main/java/com/google/gwtorm/server/StandardKeyEncoder.java
+++ b/src/main/java/com/google/gwtorm/server/StandardKeyEncoder.java
@@ -14,12 +14,10 @@
 
 package com.google.gwtorm.server;
 
-import com.google.gwtorm.client.KeyUtil.Encoder;
-
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 
-public class StandardKeyEncoder extends Encoder {
+public class StandardKeyEncoder {
   private static final char[] hexc =
       {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
           'E', 'F'};
@@ -56,8 +54,7 @@ public class StandardKeyEncoder extends Encoder {
       hexb[i] = (byte) ((i - 'a') + 10);
   }
 
-  @Override
-  public String encode(final String e) {
+  public static String encode(final String e) {
     final byte[] b;
     try {
       b = e.getBytes("UTF-8");
@@ -80,8 +77,7 @@ public class StandardKeyEncoder extends Encoder {
     return r.toString();
   }
 
-  @Override
-  public String decode(final String e) {
+  public static String decode(final String e) {
     if (e.indexOf('%') < 0) {
       return e.replace('+', ' ');
     }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
@@ -78,7 +78,10 @@ public class ChangesRestClientTest {
                                 .withLimit(10)
                                 .withOption(ListChangesOption.CURRENT_FILES)
                                 .withStart(30)
-                ).expectUrl("/changes/?q=is:open&n=10&S=30&o=CURRENT_FILES")
+                ).expectUrl("/changes/?q=is:open&n=10&S=30&o=CURRENT_FILES"),
+                queryParameter(
+                    new TestQueryRequest().withQuery("is:merged is:watched").encode()
+                ).expectUrl("/changes/?q=is%3Amerged+is%3Awatched")
         ), WRAP_IN_ARRAY_FUNCTION).iterator();
     }
 
@@ -196,6 +199,7 @@ public class ChangesRestClientTest {
 
     private static final class TestQueryRequest {
         private String query = null;
+        private boolean encode = false;
         private Integer limit = null;
         private Integer start = null;
         private String sortkey = null;
@@ -203,6 +207,11 @@ public class ChangesRestClientTest {
 
         public TestQueryRequest withQuery(String query) {
             this.query = query;
+            return this;
+        }
+
+        public TestQueryRequest encode() {
+            encode = true;
             return this;
         }
 
@@ -229,6 +238,9 @@ public class ChangesRestClientTest {
         public Changes.QueryRequest apply(Changes.QueryRequest queryRequest) {
             if (query != null) {
                 queryRequest.withQuery(query);
+            }
+            if (encode) {
+                queryRequest.encode();
             }
             if (limit != null) {
                 queryRequest.withLimit(limit);


### PR DESCRIPTION
This allows for a more convenient use of the API in the same way the Gerrit web UI is used when entering a search term.