### PR TITLE
Avoid /login authentication when using Gerrit HTTP password tokens.

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/GerritAuthData.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/GerritAuthData.java
@@ -37,6 +37,22 @@ public interface GerritAuthData {
     String getPassword();
 
     /**
+     * Returns TRUE if the password value is an HTTP password corresponding to
+     * the password token displayed on the user Settings -> HTTP Password page.
+     * Gerrit can accept two types of passwords for authentication, the normal
+     * site password (local user database, LDAP, etc) or a user-generated HTTP
+     * password token.  The HTTP password token is used for REST API requests.
+     *
+     * If this method returns TRUE, API calls should not be redirected to the
+     * /login endpoint, which
+     *
+     * @return TRUE if the password is the HTTP password token used for REST API authentication.
+     * @see <a href="https://gerrit-review.googlesource.com/Documentation/rest-api.html#authentication">Gerrit REST API authentication</a>
+     * @see <a href="https://gerrit-review.googlesource.com/Documentation/rest-api-config.html#get-info">Gerrit REST API configuration</a>
+     */
+    boolean isHttpPassword();
+
+    /**
      * HTTP URL for accessing Gerrit. Please make sure that Gerrit root URL is used.
      *
      * Example: {@code "https://gerrit-review.googlesource.com"}
@@ -58,6 +74,7 @@ public interface GerritAuthData {
         private final String host;
         private final String login;
         private final String password;
+        private final boolean httpPassword;
 
         /**
          * @param host see {@link GerritAuthData#getHost}.
@@ -72,9 +89,25 @@ public interface GerritAuthData {
          * @param password see {@link GerritAuthData#getLogin}.
          */
         public Basic(String host, String login, String password) {
+            this(host, login, password, false);
+        }
+
+        /**
+         * @param host see {@link GerritAuthData#getPassword}.
+         * @param login see {@link GerritAuthData#getLogin}.
+         * @param password see {@link GerritAuthData#getLogin}.
+         * @param httpPassword see {@link GerritAuthData@isHttpPassword}.
+         */
+        public Basic(String host, String login, String password, boolean httpPassword) {
             this.host = stripTrailingSlash(host);
             this.login = login;
             this.password = password;
+            this.httpPassword = httpPassword;
+        }
+
+        @Override
+        public boolean isHttpPassword() {
+            return httpPassword;
         }
 
         @Override

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/GerritRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/GerritRestClient.java
@@ -242,7 +242,14 @@ public class GerritRestClient implements RestClient {
             // named "gi" with a 400 HTTP status (as of 01/29/15).
             cookieStore.clear();
             return Optional.absent();
+        } else if (authData.isHttpPassword()) {
+            // Do not use a Gerrit HTTP password token to authenticate against the
+            // login page.  This will cause Gerrit to use the password to authenticate
+            // against the configured authentication source (LDAP, etc) and potentially
+            // lock the account.
+            return Optional.absent();
         }
+
         Optional<Cookie> gerritAccountCookie = findGerritAccountCookie();
         if (!gerritAccountCookie.isPresent() || gerritAccountCookie.get().isExpired(new Date())) {
             return updateGerritAuth(httpContext, client);


### PR DESCRIPTION
This change introduces a new contructor in the GerritAuthData class.
The new constructor takes an additional "httpPassword" argument,
which is used to identify whether the password being sepcified is
a special Gerrit HTTP password token (typically a password which
can be generated for each user on their Settings -> HTTP Password
page).  When set to false (the default), the password is assumed
to be a valid password for whatever authentication source Gerrit
is configured to use for normal user authentication.  When set to
true, the password is assumed to be a HTTP Password maintained
internally by Gerrit.

This fix is intended to resolve a problem where specifying an
HTTP Password for REST API calls will attempt to authenticate
against the /login page.  When Gerrit is configured to authenticate
against LDAP, this will cause authentication failure and typically
lock the LDAP account after a number of invalid attempts.