### PR TITLE
Implemented messages function for ChangeApiRestClient

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
@@ -67,6 +67,7 @@ public class GerritApiImpl extends GerritApi.NotImplemented implements GerritRes
                     gerritRestClient,
                     new ChangesParser(gerritRestClient.getGson()),
                     new CommentsParser(gerritRestClient.getGson()),
+                    new MessagesParser(gerritRestClient.getGson()),
                     new IncludedInInfoParser(gerritRestClient.getGson()),
                     new FileInfoParser(gerritRestClient.getGson()),
                     new DiffInfoParser(gerritRestClient.getGson()),

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
@@ -31,10 +31,7 @@ import com.google.gerrit.extensions.api.changes.RevertInput;
 import com.google.gerrit.extensions.api.changes.ReviewerInfo;
 import com.google.gerrit.extensions.api.changes.RevisionApi;
 import com.google.gerrit.extensions.client.ListChangesOption;
-import com.google.gerrit.extensions.common.ChangeInfo;
-import com.google.gerrit.extensions.common.CommentInfo;
-import com.google.gerrit.extensions.common.EditInfo;
-import com.google.gerrit.extensions.common.SuggestedReviewerInfo;
+import com.google.gerrit.extensions.common.*;
 import com.google.gerrit.extensions.restapi.RestApiException;
 import com.google.gerrit.extensions.restapi.Url;
 import com.google.gson.JsonElement;
@@ -66,6 +63,8 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
     private final CommitInfoParser commitInfoParser;
     private final String id;
 
+    private MessagesParser messagesParser;
+
     public ChangeApiRestClient(GerritRestClient gerritRestClient,
                                ChangesRestClient changesRestClient,
                                ChangesParser changesParser,
@@ -94,6 +93,10 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
         this.editInfoParser = editInfoParser;
         this.commitInfoParser = commitInfoParser;
         this.id = id;
+    }
+
+    public void setMessagesParser(MessagesParser messagesParser) {
+        this.messagesParser = messagesParser;
     }
 
     @Override
@@ -332,6 +335,13 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
         String url = getRequestPath() + "/submitted_together";
         JsonElement jsonElement = gerritRestClient.getRequest(url);
         return changesParser.parseChangeInfos(jsonElement);
+    }
+
+    @Override
+    public List<ChangeMessageInfo> messages() throws RestApiException {
+        String request = getRequestPath() + "/messages";
+        JsonElement jsonElement = gerritRestClient.getRequest(request);
+        return messagesParser.parseChangeMessageInfos(jsonElement);
     }
 
     protected String getRequestPath() {

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
@@ -52,6 +52,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
     private final ChangesRestClient changesRestClient;
     private final ChangesParser changesParser;
     private final CommentsParser commentsParser;
+    private final MessagesParser messagesParser;
     private final IncludedInInfoParser includedInInfoParser;
     private final FileInfoParser fileInfoParser;
     private final DiffInfoParser diffInfoParser;
@@ -63,12 +64,11 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
     private final CommitInfoParser commitInfoParser;
     private final String id;
 
-    private MessagesParser messagesParser;
-
     public ChangeApiRestClient(GerritRestClient gerritRestClient,
                                ChangesRestClient changesRestClient,
                                ChangesParser changesParser,
                                CommentsParser commentsParser,
+                               MessagesParser messagesParser,
                                IncludedInInfoParser includedInInfoParser,
                                FileInfoParser fileInfoParser,
                                DiffInfoParser diffInfoParser,
@@ -83,6 +83,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
         this.changesRestClient = changesRestClient;
         this.changesParser = changesParser;
         this.commentsParser = commentsParser;
+        this.messagesParser = messagesParser;
         this.includedInInfoParser = includedInInfoParser;
         this.fileInfoParser = fileInfoParser;
         this.diffInfoParser = diffInfoParser;
@@ -93,10 +94,6 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
         this.editInfoParser = editInfoParser;
         this.commitInfoParser = commitInfoParser;
         this.id = id;
-    }
-
-    public void setMessagesParser(MessagesParser messagesParser) {
-        this.messagesParser = messagesParser;
     }
 
     @Override
@@ -171,6 +168,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
             changesRestClient,
             changesParser,
             commentsParser,
+            messagesParser,
             includedInInfoParser,
             fileInfoParser,
             diffInfoParser,

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
@@ -38,6 +38,7 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
     private final GerritRestClient gerritRestClient;
     private final ChangesParser changesParser;
     private final CommentsParser commentsParser;
+    private final MessagesParser messagesParser;
     private final IncludedInInfoParser includedInInfoParser;
     private final FileInfoParser fileInfoParser;
     private final DiffInfoParser diffInfoParser;
@@ -51,6 +52,7 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
     public ChangesRestClient(GerritRestClient gerritRestClient,
                              ChangesParser changesParser,
                              CommentsParser commentsParser,
+                             MessagesParser messagesParser,
                              IncludedInInfoParser includedInInfoParser,
                              FileInfoParser fileInfoParser,
                              DiffInfoParser diffInfoParser,
@@ -63,6 +65,7 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
         this.gerritRestClient = gerritRestClient;
         this.changesParser = changesParser;
         this.commentsParser = commentsParser;
+        this.messagesParser = messagesParser;
         this.includedInInfoParser = includedInInfoParser;
         this.fileInfoParser = fileInfoParser;
         this.diffInfoParser = diffInfoParser;
@@ -126,8 +129,8 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
     @Override
     public ChangeApi id(String id) throws RestApiException {
         return new ChangeApiRestClient(gerritRestClient, this, changesParser, commentsParser,
-            includedInInfoParser, fileInfoParser, diffInfoParser, addReviewerResultParser, reviewResultParser,
-            suggestedReviewerInfoParser, reviewerInfoParser, editInfoParser, commitInfoParser, id);
+            messagesParser, includedInInfoParser, fileInfoParser, diffInfoParser, addReviewerResultParser,
+            reviewResultParser, suggestedReviewerInfoParser, reviewerInfoParser, editInfoParser, commitInfoParser, id);
     }
 
     @Override

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/MessagesParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/MessagesParser.java
@@ -1,0 +1,32 @@
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gerrit.extensions.common.ChangeMessageInfo;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+/**
+ * @author EFregnan
+ */
+public class MessagesParser {
+
+    private static final Type TYPE = new TypeToken<List<ChangeMessageInfo>>() {}.getType();
+
+    private final Gson gson;
+
+    public MessagesParser(Gson gson) {
+        this.gson = gson;
+    }
+
+    public List<ChangeMessageInfo> parseChangeMessageInfos(JsonElement result) {
+        return gson.fromJson(result, TYPE);
+    }
+
+    public ChangeMessageInfo parseSingleChangeMessageInfo(JsonObject result) {
+        return gson.fromJson(result, ChangeMessageInfo.class);
+    }
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
@@ -19,30 +19,16 @@ package com.urswolfer.gerrit.client.rest.http.changes;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.truth.Truth;
-import com.google.gerrit.extensions.api.changes.AbandonInput;
-import com.google.gerrit.extensions.api.changes.AddReviewerInput;
-import com.google.gerrit.extensions.api.changes.ChangeApi;
-import com.google.gerrit.extensions.api.changes.FixInput;
-import com.google.gerrit.extensions.api.changes.IncludedInInfo;
-import com.google.gerrit.extensions.api.changes.MoveInput;
-import com.google.gerrit.extensions.api.changes.RestoreInput;
-import com.google.gerrit.extensions.api.changes.RevertInput;
-import com.google.gerrit.extensions.api.changes.ReviewerInfo;
+import com.google.gerrit.extensions.api.changes.*;
 import com.google.gerrit.extensions.client.ListChangesOption;
-import com.google.gerrit.extensions.common.ChangeInfo;
-import com.google.gerrit.extensions.common.CommentInfo;
-import com.google.gerrit.extensions.common.EditInfo;
-import com.google.gerrit.extensions.common.SuggestedReviewerInfo;
+import com.google.gerrit.extensions.common.*;
 import com.google.gson.JsonElement;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
 import com.urswolfer.gerrit.client.rest.http.common.GerritRestClientBuilder;
 import org.easymock.EasyMock;
 import org.testng.annotations.Test;
 
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * @author Thomas Forrer
@@ -391,6 +377,28 @@ public class ChangeApiRestClientTest {
 
         Truth.assertThat(commentInfos).isSameAs(expectedCommentInfos);
         EasyMock.verify(gerritRestClient, commentsParser);
+    }
+
+    @Test
+    public void testMessages() throws Exception {
+        JsonElement jsonElement = EasyMock.createMock(JsonElement.class);
+        GerritRestClient gerritRestClient = new GerritRestClientBuilder()
+            .expectGet("/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/messages", jsonElement)
+            .get();
+
+        List<ChangeMessageInfo> expectedMessageInfos = new ArrayList<ChangeMessageInfo>();
+        MessagesParser messagesParser = EasyMock.createMock(MessagesParser.class);
+        EasyMock.expect(messagesParser.parseChangeMessageInfos(jsonElement)).andReturn(expectedMessageInfos).once();
+        EasyMock.replay(messagesParser);
+
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
+            null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        changeApiRestClient.setMessagesParser(messagesParser);
+
+        List<ChangeMessageInfo> messageInfos = changeApiRestClient.messages();
+
+        Truth.assertThat(messageInfos).isSameAs(expectedMessageInfos);
+        EasyMock.verify(gerritRestClient, messagesParser);
     }
 
     @Test

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
@@ -47,7 +47,7 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(reviewerInfoParser.parseReviewerInfos(jsonElement)).andReturn(expectedListReviewers).once();
         EasyMock.replay(reviewerInfoParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null,
             null, null, null, reviewerInfoParser, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
@@ -255,7 +255,7 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(suggestedReviewerInfoParser.parseSuggestReviewerInfos(jsonElement)).andReturn(expectedSuggestedReviewerInfos).once();
         EasyMock.replay(suggestedReviewerInfoParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null,
                 null, null, suggestedReviewerInfoParser, null, null, null,
                 "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
@@ -278,7 +278,7 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(suggestedReviewerInfoParser.parseSuggestReviewerInfos(jsonElement)).andReturn(expectedSuggestedReviewerInfos).once();
         EasyMock.replay(suggestedReviewerInfoParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null,
                 null, null, suggestedReviewerInfoParser, null, null, null,
                 "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
@@ -301,7 +301,7 @@ public class ChangeApiRestClientTest {
         EasyMock.replay(changesParser);
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
-            null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+            null, null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         ChangeInfo changeInfo = changeApiRestClient.check();
         Truth.assertThat(changeInfo).isSameAs(expectedChangeInfo);
@@ -321,7 +321,7 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(includedInInfoParser.parseIncludedInInfos(jsonElement)).andReturn(expectedIncludedInInfo).once();
         EasyMock.replay(includedInInfoParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
             includedInInfoParser, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         IncludedInInfo includedInInfo = changeApiRestClient.includedIn();
@@ -349,7 +349,7 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(changesParser.parseSingleChangeInfo(jsonElement)).andReturn(expectedChangeInfo).once();
         EasyMock.replay(changesParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null, null,
             null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         ChangeInfo changeInfo = changeApiRestClient.check(fixInput);
@@ -371,7 +371,7 @@ public class ChangeApiRestClientTest {
         EasyMock.replay(commentsParser);
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, commentsParser,
-            null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+            null, null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         Map<String, List<CommentInfo>> commentInfos = changeApiRestClient.comments();
 
@@ -391,9 +391,8 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(messagesParser.parseChangeMessageInfos(jsonElement)).andReturn(expectedMessageInfos).once();
         EasyMock.replay(messagesParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,  messagesParser,
             null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
-        changeApiRestClient.setMessagesParser(messagesParser);
 
         List<ChangeMessageInfo> messageInfos = changeApiRestClient.messages();
 
@@ -414,7 +413,7 @@ public class ChangeApiRestClientTest {
         EasyMock.replay(editInfoParser);
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
-            null, null, null, null, null, null, null, editInfoParser, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+            null, null, null, null, null, null, null, null, editInfoParser, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         EditInfo editInfo = changeApiRestClient.getEdit();
         Truth.assertThat(editInfo).isSameAs(expectedEditInfo);
@@ -434,7 +433,7 @@ public class ChangeApiRestClientTest {
         EasyMock.replay(changesParser);
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
-            null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+            null, null,  null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         EnumSet<ListChangesOption> options = EnumSet.of(ListChangesOption.LABELS, ListChangesOption.DETAILED_LABELS);
         ChangeInfo result = changeApiRestClient.get(options);
 
@@ -454,7 +453,7 @@ public class ChangeApiRestClientTest {
         EasyMock.replay(changesParser);
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
-            null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+            null, null,  null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         ChangeInfo result = changeApiRestClient.info();
 
         Truth.assertThat(result).isSameAs(expectedChangeInfo);
@@ -487,7 +486,7 @@ public class ChangeApiRestClientTest {
         EasyMock.replay(changesParser);
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
-            null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+            null, null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<ChangeInfo> changeInfos = changeApiRestClient.submittedTogether();
         Truth.assertThat(changeInfos).isSameAs(expectedChangeInfos);
@@ -513,6 +512,7 @@ public class ChangeApiRestClientTest {
                 gerritRestClient,
                 EasyMock.createMock(ChangesParser.class),
                 EasyMock.createMock(CommentsParser.class),
+                EasyMock.createMock(MessagesParser.class),
                 EasyMock.createMock(IncludedInInfoParser.class),
                 EasyMock.createMock(FileInfoParser.class),
                 EasyMock.createMock(DiffInfoParser.class),

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
@@ -91,7 +91,7 @@ public class ChangesRestClientTest {
         GerritRestClient gerritRestClient = setupGerritRestClient(testCase);
         ChangesParser changesParser = setupChangesParser();
 
-        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null, null, null, null, null, null, null, null, null);
 
         Changes.QueryRequest queryRequest = changes.query();
         testCase.queryParameter.apply(queryRequest).get();
@@ -107,7 +107,7 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = setupChangesParser();
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
 
-        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null, null, null, null, null, null, null, null);
         changesRestClient.query("is:open").get();
 
         EasyMock.verify(gerritRestClient);
@@ -119,7 +119,7 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = EasyMock.createMock(ChangesParser.class);
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
 
-        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null, null, null, null, null, null, null, null);
 
         ChangeApi changeApi = changesRestClient.id(123);
 
@@ -132,7 +132,7 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = EasyMock.createMock(ChangesParser.class);
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
 
-        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null, null, null, null, null, null, null, null);
 
         ChangeApi changeApi = changesRestClient.id("packages/test", 123);
 
@@ -145,7 +145,7 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = EasyMock.createMock(ChangesParser.class);
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
 
-        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null,  null, null, null, null, null, null, null, null, null);
 
         ChangeApi changeApi = changesRestClient.id("packages/test", "master", "Ieabd72e73f3da0df90fd6e8cba8f6c5dd7d120df");
 
@@ -158,7 +158,7 @@ public class ChangesRestClientTest {
         GerritRestClient gerritRestClient = setupGerritRestClient(testCase);
         ChangesParser changesParser = setupChangesParser();
 
-        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null, null, null, null, null, null, null, null, null);
 
         changes.query().get();
 
@@ -177,7 +177,7 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = setupChangesParserForCreate(changeInput,
             changeInputJsonString, changeInfo);
 
-        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null, null, null, null, null, null, null, null, null);
 
         ChangeApi changeApi = changes.create(changeInput);
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/DraftsApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/DraftsApiRestClientTest.java
@@ -44,7 +44,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
                 + revisionId + "/drafts/" + draftId, jsonObject)
             .get();
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, commentsParser, null, null, null, null, null, null, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, commentsParser, null, null, null, null, null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, commentsParser, null, null, null, null, revisionId);
 
@@ -63,7 +63,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
         CommentInfo expectedCommentInfo = new CommentInfo();
         expectedCommentInfo.id = draftId;
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null, null, null, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null, null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,
@@ -86,7 +86,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
             .expectGetGson()
             .get();
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null, null, null, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null, null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,
@@ -106,7 +106,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
                 "revisions/" + revisionId + "/drafts/" + draftId)
             .get();
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null, null, null, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null,null, null, null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/MessagesParserTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/MessagesParserTest.java
@@ -1,0 +1,57 @@
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.ChangeMessageInfo;
+import com.google.gson.JsonElement;
+import com.urswolfer.gerrit.client.rest.http.common.*;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author EFregnan
+ */
+public class MessagesParserTest extends AbstractParserTest {
+    private static final List<ChangeMessageInfo> MESSAGES_INFOS = new ArrayList<ChangeMessageInfo>();
+
+    static {
+        AccountInfo accountInfo = new AccountInfoBuilder()
+            .withName("EFregnan")
+            .withEmail("abc@gmail.com")
+            .withUsername("efregnan")
+            .withAccountId(1000000)
+            .get();
+
+        MESSAGES_INFOS.add(new ChangeMessageInfoBuilder()
+                    .withId("EAF")
+                    .withMessage("Patch Set 1: This is the first message.")
+                    .withDate("2019-11-28 22:28:50")
+                    .withAuthor(accountInfo)
+                    .withRevisionNumber(1)
+                    .get()
+        );
+        MESSAGES_INFOS.add(new ChangeMessageInfoBuilder()
+                    .withId("YH-egE")
+                    .withMessage("i think so")
+                    .withDate("2019-11-28 22:33:12")
+                    .withAuthor(accountInfo)
+                    .withRevisionNumber(2)
+                    .get()
+        );
+    }
+
+    private MessagesParser messagesParser = new MessagesParser(getGson());
+
+    @Test
+    public void testParseCommentInfos() throws Exception {
+        List<ChangeMessageInfo> messages = parseMessages();
+        GerritAssert.assertEquals(messages, MESSAGES_INFOS);
+    }
+
+    private List<ChangeMessageInfo> parseMessages() throws Exception {
+        JsonElement jsonElement = getJsonElement("messages.json");
+        return messagesParser.parseChangeMessageInfos(jsonElement);
+    }
+}
+

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerApiRestClientTest.java
@@ -42,7 +42,7 @@ public class ReviewerApiRestClientTest extends AbstractParserTest {
             .expectGetGson()
             .get();
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
-            null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+            null, null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         ReviewerApiRestClient reviewerApiRestClient = new ReviewerApiRestClient(gerritRestClient, changeApiRestClient, ACCOUNT_ID);
         Map<String, Short> votes = reviewerApiRestClient.votes();
 
@@ -57,7 +57,7 @@ public class ReviewerApiRestClientTest extends AbstractParserTest {
             .expectDelete("/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/reviewers/" + ACCOUNT_ID + "/votes/" + LABEL)
             .get();
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
-            null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+            null, null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         ReviewerApiRestClient reviewerApiRestClient = new ReviewerApiRestClient(gerritRestClient, changeApiRestClient, ACCOUNT_ID);
         reviewerApiRestClient.deleteVote(LABEL);
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
@@ -383,6 +383,7 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
     private ChangesRestClient getChangesRestClient(GerritRestClient gerritRestClient) {
         ChangesParser changesParser = EasyMock.createMock(ChangesParser.class);
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
+        MessagesParser messagesParser = EasyMock.createMock(MessagesParser.class);
         IncludedInInfoParser includedInInfoParser = EasyMock.createMock(IncludedInInfoParser.class);
         FileInfoParser fileInfoParser = EasyMock.createMock(FileInfoParser.class);
         DiffInfoParser diffInfoParser = EasyMock.createMock(DiffInfoParser.class);
@@ -391,7 +392,7 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
         AddReviewerResultParser addReviewerResultParser = EasyMock.createMock(AddReviewerResultParser.class);
         ReviewResultParser reviewResultParser = EasyMock.createMock(ReviewResultParser.class);
         CommitInfoParser commitInfoParser = EasyMock.createMock(CommitInfoParser.class);
-        return new ChangesRestClient(gerritRestClient, changesParser, commentsParser, includedInInfoParser, fileInfoParser, diffInfoParser, null, reviewerInfoParser, editInfoParser, addReviewerResultParser, reviewResultParser, commitInfoParser);
+        return new ChangesRestClient(gerritRestClient, changesParser, commentsParser, messagesParser, includedInInfoParser, fileInfoParser, diffInfoParser, null, reviewerInfoParser, editInfoParser, addReviewerResultParser, reviewResultParser, commitInfoParser);
     }
 
     private ChangesRestClient getChangesRestClient(GerritRestClient gerritRestClient, CommentsParser commentsParser) {
@@ -399,6 +400,7 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
                 gerritRestClient,
                 EasyMock.createMock(ChangesParser.class),
                 commentsParser,
+                EasyMock.createMock(MessagesParser.class),
                 EasyMock.createMock(IncludedInInfoParser.class),
                 EasyMock.createMock(FileInfoParser.class),
                 EasyMock.createMock(DiffInfoParser.class),

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/ChangeMessageInfoBuilder.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/ChangeMessageInfoBuilder.java
@@ -1,0 +1,54 @@
+package com.urswolfer.gerrit.client.rest.http.common;
+
+import com.google.gerrit.extensions.client.Comment;
+import com.google.gerrit.extensions.client.Side;
+import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.ChangeMessageInfo;
+
+import java.sql.Timestamp;
+
+/**
+ * @author EFregnan
+ */
+public class ChangeMessageInfoBuilder extends AbstractBuilder {
+    private final ChangeMessageInfo changeMessageInfo = new ChangeMessageInfo();
+
+    public ChangeMessageInfo get() {
+        return changeMessageInfo;
+    }
+
+    public ChangeMessageInfoBuilder withAuthor(AccountInfo author) {
+        changeMessageInfo.author = author;
+        return this;
+    }
+
+    public ChangeMessageInfoBuilder withId(String id) {
+        changeMessageInfo.id = id;
+        return this;
+    }
+
+    public ChangeMessageInfoBuilder withTag(String tag) {
+        changeMessageInfo.tag = tag;
+        return this;
+    }
+
+    public ChangeMessageInfoBuilder withDate(String date) {
+        changeMessageInfo.date = timestamp(date);
+        return this;
+    }
+
+    public ChangeMessageInfoBuilder withRealAuthor(AccountInfo realAuthor) {
+        changeMessageInfo.realAuthor = realAuthor;
+        return this;
+    }
+
+    public ChangeMessageInfoBuilder withMessage(String message) {
+        changeMessageInfo.message = message;
+        return this;
+    }
+
+    public ChangeMessageInfoBuilder withRevisionNumber(int revisionNumber) {
+        changeMessageInfo._revisionNumber = revisionNumber;
+        return this;
+    }
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/GerritAssert.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/GerritAssert.java
@@ -71,6 +71,10 @@ public class GerritAssert {
         assertXmlOutputEqual(actual, expected);
     }
 
+    public static void assertEquals(List<ChangeMessageInfo> actual, List<ChangeMessageInfo> expected) {
+        assertXmlOutputEqual(actual, expected);
+    }
+
     public static void assertEquals(DiffInfo actual, DiffInfo expected) {
         assertXmlOutputEqual(actual, expected);
     }

--- a/src/test/resources/com/urswolfer/gerrit/client/rest/http/changes/messages.json
+++ b/src/test/resources/com/urswolfer/gerrit/client/rest/http/changes/messages.json
@@ -1,0 +1,27 @@
+)]}'
+[
+    {
+        "id": "EAF",
+        "author": {
+        "_account_id": 1000000,
+        "name": "EFregnan",
+        "email": "abc@gmail.com",
+        "username": "efregnan"
+    },
+        "date": "2019-11-28 22:28:50.419000000",
+        "message": "Patch Set 1: This is the first message.",
+        "_revision_number": 1
+    },
+    {
+        "id": "YH-egE",
+        "author": {
+        "_account_id": 1000000,
+        "name": "EFregnan",
+        "email": "abc@gmail.com",
+        "username": "efregnan"
+    },
+        "date": "2019-11-28 22:33:12.332000000",
+        "message": "i think so",
+        "_revision_number": 2
+    }
+]


### PR DESCRIPTION
Since it seemed to me that it was still not there, I have implemented the messages() function, together with the related tests.

Since modifying the constructor of ChangeApiRestClient to accept an object of the new class MessagesParser would have requested further modifications in the code-base, I took the liberty to add a setter for messagesParser. 
I hope this is not a problem. If the PR is fine, I will fix this in a follow-up PR.

Thank you!

Best, 
   Enrico