### PR TITLE
Implemented robotComment functionalities

### DIFF
--- a/src/main/java/com/google/gerrit/extensions/common/RobotCommentInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/RobotCommentInfo.java
@@ -14,13 +14,22 @@
 
 package com.google.gerrit.extensions.common;
 
+import com.google.common.base.Objects;
+
 import java.util.List;
 import java.util.Map;
 
 public class RobotCommentInfo extends CommentInfo {
+
   public String robotId;
   public String robotRunId;
   public String url;
   public Map<String, String> properties;
   public List<FixSuggestionInfo> fixSuggestions;
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(super.hashCode(), robotId, robotRunId, url, properties, fixSuggestions);
+  }
 }
+

--- a/src/main/java/com/google/gerrit/extensions/common/RobotCommentInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/RobotCommentInfo.java
@@ -14,22 +14,14 @@
 
 package com.google.gerrit.extensions.common;
 
-import com.google.common.base.Objects;
-
 import java.util.List;
 import java.util.Map;
 
 public class RobotCommentInfo extends CommentInfo {
-
   public String robotId;
   public String robotRunId;
   public String url;
   public Map<String, String> properties;
   public List<FixSuggestionInfo> fixSuggestions;
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(super.hashCode(), robotId, robotRunId, url, properties, fixSuggestions);
-  }
 }
 

--- a/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
@@ -67,6 +67,7 @@ public class GerritApiImpl extends GerritApi.NotImplemented implements GerritRes
                     gerritRestClient,
                     new ChangesParser(gerritRestClient.getGson()),
                     new CommentsParser(gerritRestClient.getGson()),
+                    new RobotCommentsParser(gerritRestClient.getGson()),
                     new MessagesParser(gerritRestClient.getGson()),
                     new IncludedInInfoParser(gerritRestClient.getGson()),
                     new FileInfoParser(gerritRestClient.getGson()),

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
@@ -53,6 +53,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
     private final ChangesRestClient changesRestClient;
     private final ChangesParser changesParser;
     private final CommentsParser commentsParser;
+    private final RobotCommentsParser robotCommentsParser;
     private final MessagesParser messagesParser;
     private final IncludedInInfoParser includedInInfoParser;
     private final FileInfoParser fileInfoParser;
@@ -70,6 +71,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
                                ChangesRestClient changesRestClient,
                                ChangesParser changesParser,
                                CommentsParser commentsParser,
+                               RobotCommentsParser robotCommentsParser,
                                MessagesParser messagesParser,
                                IncludedInInfoParser includedInInfoParser,
                                FileInfoParser fileInfoParser,
@@ -85,6 +87,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
         this.changesRestClient = changesRestClient;
         this.changesParser = changesParser;
         this.commentsParser = commentsParser;
+        this.robotCommentsParser = robotCommentsParser;
         this.messagesParser = messagesParser;
         this.includedInInfoParser = includedInInfoParser;
         this.fileInfoParser = fileInfoParser;
@@ -171,6 +174,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
             changesRestClient,
             changesParser,
             commentsParser,
+            robotCommentsParser,
             messagesParser,
             includedInInfoParser,
             fileInfoParser,
@@ -321,6 +325,13 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
       String request = getRequestPath() + "/comments";
       JsonElement jsonElement = gerritRestClient.getRequest(request);
       return commentsParser.parseCommentInfos(jsonElement);
+    }
+
+    @Override
+    public  Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException {
+        String request = getRequestPath() + "/robotcomments";
+        JsonElement jsonElement = gerritRestClient.getRequest(request);
+        return robotCommentsParser.parseRobotCommentInfos(jsonElement);
     }
 
     @Override

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
@@ -38,6 +38,7 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
     private final GerritRestClient gerritRestClient;
     private final ChangesParser changesParser;
     private final CommentsParser commentsParser;
+    private final RobotCommentsParser robotCommentsParser;
     private final MessagesParser messagesParser;
     private final IncludedInInfoParser includedInInfoParser;
     private final FileInfoParser fileInfoParser;
@@ -52,6 +53,7 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
     public ChangesRestClient(GerritRestClient gerritRestClient,
                              ChangesParser changesParser,
                              CommentsParser commentsParser,
+                             RobotCommentsParser robotCommentsParser,
                              MessagesParser messagesParser,
                              IncludedInInfoParser includedInInfoParser,
                              FileInfoParser fileInfoParser,
@@ -65,6 +67,7 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
         this.gerritRestClient = gerritRestClient;
         this.changesParser = changesParser;
         this.commentsParser = commentsParser;
+        this.robotCommentsParser = robotCommentsParser;
         this.messagesParser = messagesParser;
         this.includedInInfoParser = includedInInfoParser;
         this.fileInfoParser = fileInfoParser;
@@ -129,7 +132,7 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
     @Override
     public ChangeApi id(String id) throws RestApiException {
         return new ChangeApiRestClient(gerritRestClient, this, changesParser, commentsParser,
-            messagesParser, includedInInfoParser, fileInfoParser, diffInfoParser, addReviewerResultParser,
+            robotCommentsParser, messagesParser, includedInInfoParser, fileInfoParser, diffInfoParser, addReviewerResultParser,
             reviewResultParser, suggestedReviewerInfoParser, reviewerInfoParser, editInfoParser, commitInfoParser, id);
     }
 

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentsParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentsParser.java
@@ -1,0 +1,36 @@
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gerrit.extensions.common.RobotCommentInfo;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.TreeMap;
+
+/**
+ * @author EFregnan
+ */
+
+public class RobotCommentsParser {
+
+    private static final Type TYPE = new TypeToken<TreeMap<String, List<RobotCommentInfo>>>() {}.getType();
+
+    private final Gson gson;
+
+    public RobotCommentsParser(Gson gson) {
+        this.gson = gson;
+    }
+
+    public TreeMap<String, List<RobotCommentInfo>> parseRobotCommentInfos(JsonElement result) {
+        return gson.fromJson(result, TYPE);
+    }
+
+    public RobotCommentInfo parseSingleRobotCommentInfo(JsonObject result) {
+        return gson.fromJson(result, RobotCommentInfo.class);
+    }
+
+}
+

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentsParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentsParser.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2020 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.urswolfer.gerrit.client.rest.http.changes;
 
 import com.google.common.reflect.TypeToken;

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
@@ -48,8 +48,9 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(reviewerInfoParser.parseReviewerInfos(jsonElement)).andReturn(expectedListReviewers).once();
         EasyMock.replay(reviewerInfoParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null,
-            null, null, null, reviewerInfoParser, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
+            null, null, null, null, null,
+            null, null, reviewerInfoParser, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<ReviewerInfo> listReviewers = changeApiRestClient.listReviewers();
@@ -256,9 +257,10 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(suggestedReviewerInfoParser.parseSuggestReviewerInfos(jsonElement)).andReturn(expectedSuggestedReviewerInfos).once();
         EasyMock.replay(suggestedReviewerInfoParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null,
-                null, null, suggestedReviewerInfoParser, null, null, null,
-                "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,null,
+            null, null, null, null, null,
+            null, suggestedReviewerInfoParser, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<SuggestedReviewerInfo> suggestedReviewerInfos = changeApiRestClient.suggestReviewers("J").get();
 
@@ -279,9 +281,10 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(suggestedReviewerInfoParser.parseSuggestReviewerInfos(jsonElement)).andReturn(expectedSuggestedReviewerInfos).once();
         EasyMock.replay(suggestedReviewerInfoParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null,
-                null, null, suggestedReviewerInfoParser, null, null, null,
-                "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
+            null, null, null, null, null,
+            null, suggestedReviewerInfoParser, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<SuggestedReviewerInfo> suggestedReviewerInfos = changeApiRestClient.suggestReviewers("J").withLimit(5).get();
 
@@ -301,8 +304,10 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(changesParser.parseSingleChangeInfo(jsonElement)).andReturn(expectedChangeInfo).once();
         EasyMock.replay(changesParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
-            null, null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null, null,
+            null, null, null, null, null,
+            null, null, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         ChangeInfo changeInfo = changeApiRestClient.check();
         Truth.assertThat(changeInfo).isSameAs(expectedChangeInfo);
@@ -323,7 +328,9 @@ public class ChangeApiRestClientTest {
         EasyMock.replay(includedInInfoParser);
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
-            includedInInfoParser, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+            null, includedInInfoParser, null, null, null,
+            null, null, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         IncludedInInfo includedInInfo = changeApiRestClient.includedIn();
         Truth.assertThat(includedInInfo).isSameAs(expectedIncludedInInfo);
@@ -351,7 +358,9 @@ public class ChangeApiRestClientTest {
         EasyMock.replay(changesParser);
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null, null,
-            null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+            null,null, null, null, null,
+            null, null, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         ChangeInfo changeInfo = changeApiRestClient.check(fixInput);
         Truth.assertThat(changeInfo).isSameAs(expectedChangeInfo);
@@ -371,13 +380,38 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(commentsParser.parseCommentInfos(jsonElement)).andReturn(expectedCommentInfos).once();
         EasyMock.replay(commentsParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, commentsParser,
-            null, null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, commentsParser, null,
+            null, null, null, null, null,
+            null, null, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         Map<String, List<CommentInfo>> commentInfos = changeApiRestClient.comments();
 
         Truth.assertThat(commentInfos).isSameAs(expectedCommentInfos);
         EasyMock.verify(gerritRestClient, commentsParser);
+    }
+
+    @Test
+    public void testRobotComments() throws Exception {
+        JsonElement jsonElement = EasyMock.createMock(JsonElement.class);
+        GerritRestClient gerritRestClient = new GerritRestClientBuilder()
+            .expectGet("/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/robotcomments", jsonElement)
+            .get();
+
+        TreeMap<String, List<RobotCommentInfo>> expectedRobotCommentInfos = Maps.newTreeMap();
+        RobotCommentsParser robotCommentsParser = EasyMock.createMock(RobotCommentsParser.class);
+        EasyMock.expect(robotCommentsParser.parseRobotCommentInfos(jsonElement)).andReturn(expectedRobotCommentInfos).once();
+        EasyMock.replay(robotCommentsParser);
+
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, robotCommentsParser,
+            null, null, null, null, null,
+            null, null, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+
+        Map<String, List<RobotCommentInfo>> robotCommentInfos = changeApiRestClient.robotComments();
+
+        Truth.assertThat(robotCommentInfos).isSameAs(expectedRobotCommentInfos);
+        EasyMock.verify(gerritRestClient, robotCommentsParser);
     }
 
     @Test
@@ -392,8 +426,10 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(messagesParser.parseChangeMessageInfos(jsonElement)).andReturn(expectedMessageInfos).once();
         EasyMock.replay(messagesParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,  messagesParser,
-            null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
+            messagesParser, null, null, null, null,
+            null, null, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<ChangeMessageInfo> messageInfos = changeApiRestClient.messages();
 
@@ -413,8 +449,10 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(editInfoParser.parseEditInfos(jsonElement)).andReturn(Lists.newArrayList(expectedEditInfo)).once();
         EasyMock.replay(editInfoParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
-            null, null, null, null, null, null, null, null, editInfoParser, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
+            null, null, null, null, null,
+            null, null, null, editInfoParser, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         EditInfo editInfo = changeApiRestClient.getEdit();
         Truth.assertThat(editInfo).isSameAs(expectedEditInfo);
@@ -433,8 +471,10 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(changesParser.parseSingleChangeInfo(jsonElement)).andReturn(expectedChangeInfo).once();
         EasyMock.replay(changesParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
-            null, null,  null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null, null,
+            null, null,  null, null, null,
+            null, null, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         EnumSet<ListChangesOption> options = EnumSet.of(ListChangesOption.LABELS, ListChangesOption.DETAILED_LABELS);
         ChangeInfo result = changeApiRestClient.get(options);
 
@@ -475,8 +515,9 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(changesParser.parseSingleChangeInfo(jsonElement)).andReturn(expectedChangeInfo).once();
         EasyMock.replay(changesParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
-            null, null,  null, null, null, null, null, null, null, null, expectedChangeId);
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null, null,
+            null, null,  null, null, null,
+            null, null, null, null, null, expectedChangeId);
         ChangeInfo result = changeApiRestClient.get();
 
         Truth.assertThat(result).isSameAs(expectedChangeInfo);
@@ -505,8 +546,9 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(changesParser.parseSingleChangeInfo(jsonElement)).andReturn(expectedChangeInfo).once();
         EasyMock.replay(changesParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
-            null, null,  null, null, null, null, null, null, null, null, expectedChangeId);
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null, null,
+            null, null,  null, null, null,
+            null, null, null, null, null, expectedChangeId);
         ChangeInfo result = changeApiRestClient.get();
 
         Truth.assertThat(result).isSameAs(expectedChangeInfo);
@@ -524,8 +566,10 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(changesParser.parseSingleChangeInfo(jsonElement)).andReturn(expectedChangeInfo).once();
         EasyMock.replay(changesParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
-            null, null,  null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null, null,
+            null, null,  null, null, null,
+            null, null, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         ChangeInfo result = changeApiRestClient.info();
 
         Truth.assertThat(result).isSameAs(expectedChangeInfo);
@@ -557,8 +601,10 @@ public class ChangeApiRestClientTest {
         EasyMock.expect(changesParser.parseChangeInfos(jsonElement)).andReturn(expectedChangeInfos).once();
         EasyMock.replay(changesParser);
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
-            null, null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null, null,
+            null, null, null, null, null,
+            null, null, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<ChangeInfo> changeInfos = changeApiRestClient.submittedTogether();
         Truth.assertThat(changeInfos).isSameAs(expectedChangeInfos);
@@ -584,6 +630,7 @@ public class ChangeApiRestClientTest {
                 gerritRestClient,
                 EasyMock.createMock(ChangesParser.class),
                 EasyMock.createMock(CommentsParser.class),
+                EasyMock.createMock(RobotCommentsParser.class),
                 EasyMock.createMock(MessagesParser.class),
                 EasyMock.createMock(IncludedInInfoParser.class),
                 EasyMock.createMock(FileInfoParser.class),

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
@@ -91,7 +91,9 @@ public class ChangesRestClientTest {
         GerritRestClient gerritRestClient = setupGerritRestClient(testCase);
         ChangesParser changesParser = setupChangesParser();
 
-        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null,
+            null, null, null, null, null,
+            null, null, null, null, null);
 
         Changes.QueryRequest queryRequest = changes.query();
         testCase.queryParameter.apply(queryRequest).get();
@@ -107,7 +109,9 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = setupChangesParser();
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
 
-        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null,
+            null, null, null, null, null,
+            null, null, null, null, null);
         changesRestClient.query("is:open").get();
 
         EasyMock.verify(gerritRestClient);
@@ -119,7 +123,9 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = EasyMock.createMock(ChangesParser.class);
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
 
-        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null,
+            null, null, null, null, null,
+            null, null, null, null, null);
 
         ChangeApi changeApi = changesRestClient.id(123);
 
@@ -132,7 +138,9 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = EasyMock.createMock(ChangesParser.class);
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
 
-        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null,
+            null, null, null, null, null,
+            null, null, null, null, null);
 
         ChangeApi changeApi = changesRestClient.id("packages/test", 123);
 
@@ -145,7 +153,9 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = EasyMock.createMock(ChangesParser.class);
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
 
-        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null,  null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null,
+            null,  null, null, null, null,
+            null, null, null, null, null);
 
         ChangeApi changeApi = changesRestClient.id("packages/test", "master", "Ieabd72e73f3da0df90fd6e8cba8f6c5dd7d120df");
 
@@ -158,7 +168,9 @@ public class ChangesRestClientTest {
         GerritRestClient gerritRestClient = setupGerritRestClient(testCase);
         ChangesParser changesParser = setupChangesParser();
 
-        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser,null, null,
+            null, null, null, null, null,
+            null, null, null, null, null);
 
         changes.query().get();
 
@@ -177,7 +189,9 @@ public class ChangesRestClientTest {
         ChangesParser changesParser = setupChangesParserForCreate(changeInput,
             changeInputJsonString, changeInfo);
 
-        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null, null, null, null, null, null, null, null, null, null);
+        ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null,
+            null, null, null, null, null,
+            null, null, null, null, null);
 
         ChangeApi changeApi = changes.create(changeInput);
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/DraftsApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/DraftsApiRestClientTest.java
@@ -44,7 +44,9 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
                 + revisionId + "/drafts/" + draftId, jsonObject)
             .get();
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, commentsParser, null, null, null, null, null, null, null, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, commentsParser, null,
+            null, null, null, null, null, null, null,
+            null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, commentsParser, null, null, null, null, revisionId);
 
@@ -63,7 +65,9 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
         CommentInfo expectedCommentInfo = new CommentInfo();
         expectedCommentInfo.id = draftId;
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null, null, null, null, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
+            null, null, null, null, null,
+            null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,
@@ -86,7 +90,9 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
             .expectGetGson()
             .get();
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null, null, null, null, null, null, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
+            null, null, null, null, null,
+            null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,
@@ -106,7 +112,9 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
                 "revisions/" + revisionId + "/drafts/" + draftId)
             .get();
 
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null, null,null, null, null, null, null, null, null, null,
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
+            null, null,null, null, null,
+            null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerApiRestClientTest.java
@@ -41,8 +41,10 @@ public class ReviewerApiRestClientTest extends AbstractParserTest {
             .expectGet("/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/reviewers/" + ACCOUNT_ID + "/votes", jsonElement)
             .expectGetGson()
             .get();
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
+            null, null, null, null, null,
+            null, null, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         ReviewerApiRestClient reviewerApiRestClient = new ReviewerApiRestClient(gerritRestClient, changeApiRestClient, ACCOUNT_ID);
         Map<String, Short> votes = reviewerApiRestClient.votes();
 
@@ -56,8 +58,10 @@ public class ReviewerApiRestClientTest extends AbstractParserTest {
         GerritRestClient gerritRestClient = new GerritRestClientBuilder()
             .expectDelete("/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/reviewers/" + ACCOUNT_ID + "/votes/" + LABEL)
             .get();
-        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
-            null, null, null, null, null, null, null, null, null, null, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
+            null, null, null, null, null,
+            null, null, null, null, null,
+            "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         ReviewerApiRestClient reviewerApiRestClient = new ReviewerApiRestClient(gerritRestClient, changeApiRestClient, ACCOUNT_ID);
         reviewerApiRestClient.deleteVote(LABEL);
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
@@ -383,6 +383,7 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
     private ChangesRestClient getChangesRestClient(GerritRestClient gerritRestClient) {
         ChangesParser changesParser = EasyMock.createMock(ChangesParser.class);
         CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
+        RobotCommentsParser robotCommentsParser = EasyMock.createMock(RobotCommentsParser.class);
         MessagesParser messagesParser = EasyMock.createMock(MessagesParser.class);
         IncludedInInfoParser includedInInfoParser = EasyMock.createMock(IncludedInInfoParser.class);
         FileInfoParser fileInfoParser = EasyMock.createMock(FileInfoParser.class);
@@ -392,7 +393,7 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
         AddReviewerResultParser addReviewerResultParser = EasyMock.createMock(AddReviewerResultParser.class);
         ReviewResultParser reviewResultParser = EasyMock.createMock(ReviewResultParser.class);
         CommitInfoParser commitInfoParser = EasyMock.createMock(CommitInfoParser.class);
-        return new ChangesRestClient(gerritRestClient, changesParser, commentsParser, messagesParser, includedInInfoParser, fileInfoParser, diffInfoParser, null, reviewerInfoParser, editInfoParser, addReviewerResultParser, reviewResultParser, commitInfoParser);
+        return new ChangesRestClient(gerritRestClient, changesParser, commentsParser, robotCommentsParser, messagesParser, includedInInfoParser, fileInfoParser, diffInfoParser, null, reviewerInfoParser, editInfoParser, addReviewerResultParser, reviewResultParser, commitInfoParser);
     }
 
     private ChangesRestClient getChangesRestClient(GerritRestClient gerritRestClient, CommentsParser commentsParser) {
@@ -400,6 +401,7 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
                 gerritRestClient,
                 EasyMock.createMock(ChangesParser.class),
                 commentsParser,
+                EasyMock.createMock(RobotCommentsParser.class),
                 EasyMock.createMock(MessagesParser.class),
                 EasyMock.createMock(IncludedInInfoParser.class),
                 EasyMock.createMock(FileInfoParser.class),

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentsParserTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentsParserTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2020 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.urswolfer.gerrit.client.rest.http.changes;
 
 import com.google.common.base.Function;

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentsParserTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentsParserTest.java
@@ -1,0 +1,92 @@
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.truth.Truth;
+import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.RobotCommentInfo;
+import com.google.gson.JsonElement;
+import com.urswolfer.gerrit.client.rest.http.common.*;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * @author EFregnan
+ */
+public class RobotCommentsParserTest extends AbstractParserTest {
+    private static final TreeMap<String, List<RobotCommentInfo>> ROBOT_COMMENT_INFOS = Maps.newTreeMap();
+
+    static {
+        AccountInfo accountInfo = new AccountInfoBuilder()
+            .withName("CodeAnalyzer")
+            .withEmail("code.analyzer@example.com")
+            .withUsername("C_Analyzer")
+            .withAccountId(1000000)
+            .get();
+
+        ROBOT_COMMENT_INFOS.put("playingfield.iml", Lists.newArrayList(
+            new RobotCommentInfoBuilder()
+                .withId("TvcXrmjM")
+                .withLine(1)
+                .withMessage("Unused import")
+                .withUpdated("2014-05-28 19:14:50")
+                .withAuthor(accountInfo)
+                .withRobotId("importChecker")
+                .withRobotRunId("12x1375aa8626ea7149792831fe2ed85e80s1r03")
+                .get()
+        ));
+        ROBOT_COMMENT_INFOS.put("src/ch/tf/playingfield/PlayingField.java", Lists.newArrayList(
+            new RobotCommentInfoBuilder()
+                .withId("BsaWsvaK")
+                .withLine(4)
+                .withMessage("Reformat imports")
+                .withUpdated("2014-05-28 19:04:21")
+                .withAuthor(accountInfo)
+                .withRobotId("importChecker")
+                .withRobotRunId("12x1375aa8626ea7149792831fe2ed85e80s1r03")
+                .get(),
+            new RobotCommentInfoBuilder()
+                .withId("TalZsvaK")
+                .withLine(12)
+                .withMessage("Wrong indentation")
+                .withUpdated("2014-05-28 19:14:50")
+                .withAuthor(accountInfo)
+                .withRobotId("styleChecker")
+                .withRobotRunId("24x1375aa8626ea7149792831fe2ed85e80bst12")
+                .get()
+        ));
+    }
+
+    private RobotCommentsParser robotCommentsParser = new RobotCommentsParser(getGson());
+
+    @Test
+    public void testParseRobotCommentsFileName() throws Exception {
+        TreeMap<String, List<RobotCommentInfo>> robotComments = parseRobotComments();
+        Truth.assertThat(robotComments.keySet()).isEqualTo(ROBOT_COMMENT_INFOS.keySet());
+    }
+
+    @Test
+    public void testParseCommentInfosForFile() throws Exception {
+        TreeMap<String, List<RobotCommentInfo>> robotComments = parseRobotComments();
+        Function<List<RobotCommentInfo>, Integer> listSizeFunction = robotCommentInfos -> robotCommentInfos.size();
+        SortedMap<String, Integer> commentsPerFile = Maps.transformValues(robotComments, listSizeFunction);
+        SortedMap<String, Integer> expectedCommentsPerFile = Maps.transformValues(ROBOT_COMMENT_INFOS, listSizeFunction);
+
+        Truth.assertThat(commentsPerFile).isEqualTo(expectedCommentsPerFile);
+    }
+
+    @Test
+    public void testParseCommentInfos() throws Exception {
+        TreeMap<String, List<RobotCommentInfo>> robotComments = parseRobotComments();
+        GerritAssert.assertRobotCommentsEquals(robotComments, ROBOT_COMMENT_INFOS);
+    }
+
+    private TreeMap<String, List<RobotCommentInfo>> parseRobotComments() throws Exception {
+        JsonElement jsonElement = getJsonElement("robotcomments.json");
+        return robotCommentsParser.parseRobotCommentInfos(jsonElement);
+    }
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/GerritAssert.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/GerritAssert.java
@@ -89,4 +89,9 @@ public class GerritAssert {
 
         Truth.assertThat(actualXml).isEqualTo(expectedXml);
     }
+
+    public static void assertRobotCommentsEquals(TreeMap<String, List<RobotCommentInfo>> actual, TreeMap<String, List<RobotCommentInfo>> expected) {
+        assertXmlOutputEqual(actual, expected);
+    }
+
 }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/RobotCommentInfoBuilder.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/RobotCommentInfoBuilder.java
@@ -1,0 +1,92 @@
+package com.urswolfer.gerrit.client.rest.http.common;
+
+import com.google.gerrit.extensions.client.Comment;
+import com.google.gerrit.extensions.client.Side;
+import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.FixSuggestionInfo;
+import com.google.gerrit.extensions.common.RobotCommentInfo;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author EFregnan
+ */
+public class RobotCommentInfoBuilder extends AbstractBuilder {
+    private final RobotCommentInfo robotCommentInfo = new RobotCommentInfo();
+
+    public RobotCommentInfo get() {
+        return robotCommentInfo;
+    }
+
+    public RobotCommentInfoBuilder withAuthor(AccountInfo author) {
+        robotCommentInfo.author = author;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withId(String id) {
+        robotCommentInfo.id = id;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withPath(String path) {
+        robotCommentInfo.path = path;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withSide(Side side) {
+        robotCommentInfo.side = side;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withLine(int line) {
+        robotCommentInfo.line = line;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withRange(Comment.Range range) {
+        robotCommentInfo.range = range;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withInReplyTo(String inReplyTo) {
+        robotCommentInfo.inReplyTo = inReplyTo;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withUpdated(String updated) {
+        robotCommentInfo.updated = timestamp(updated);
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withMessage(String message) {
+        robotCommentInfo.message = message;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withRobotId(String robotId) {
+        robotCommentInfo.robotId = robotId;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withRobotRunId(String robotRunId) {
+        robotCommentInfo.robotRunId = robotRunId;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withUrl(String url) {
+        robotCommentInfo.url = url;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withProperties(Map<String, String> properties) {
+        robotCommentInfo.properties = properties;
+        return this;
+    }
+
+    public RobotCommentInfoBuilder withFixSuggestions(List<FixSuggestionInfo> fixSuggestions) {
+        robotCommentInfo.fixSuggestions = fixSuggestions;
+        return this;
+    }
+
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/common/RobotCommentInfoBuilder.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/common/RobotCommentInfoBuilder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2020 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.urswolfer.gerrit.client.rest.http.common;
 
 import com.google.gerrit.extensions.client.Comment;

--- a/src/test/resources/com/urswolfer/gerrit/client/rest/http/changes/robotcomments.json
+++ b/src/test/resources/com/urswolfer/gerrit/client/rest/http/changes/robotcomments.json
@@ -1,0 +1,49 @@
+)]}'
+{
+    "playingfield.iml": [
+        {
+            "id": "TvcXrmjM",
+            "line": 1,
+            "message": "Unused import",
+            "updated": "2014-05-28 19:14:50.629000000",
+            "author": {
+                "_account_id": 1000000,
+                "name": "CodeAnalyzer",
+                "email": "code.analyzer@example.com",
+                "username": "C_Analyzer"
+            },
+            "robot_id": "importChecker",
+            "robot_run_id": "12x1375aa8626ea7149792831fe2ed85e80s1r03"
+        }
+    ],
+    "src/ch/tf/playingfield/PlayingField.java": [
+        {
+            "id": "BsaWsvaK",
+            "line": 4,
+            "message": "Reformat imports",
+            "updated": "2014-05-28 19:04:21.629000000",
+            "author": {
+                "_account_id": 1000000,
+                "name": "CodeAnalyzer",
+                "email": "code.analyzer@example.com",
+                "username": "C_Analyzer"
+            },
+            "robot_id": "importChecker",
+            "robot_run_id": "12x1375aa8626ea7149792831fe2ed85e80s1r03"
+        },
+        {
+            "id": "TalZsvaK",
+            "line": 12,
+            "message": "Wrong indentation",
+            "updated": "2014-05-28 19:14:50.629000000",
+            "author": {
+                "_account_id": 1000000,
+                "name": "CodeAnalyzer",
+                "email": "code.analyzer@example.com",
+                "username": "C_Analyzer"
+            },
+            "robot_id": "styleChecker",
+            "robot_run_id": "24x1375aa8626ea7149792831fe2ed85e80bst12"
+        }
+    ]
+}


### PR DESCRIPTION
Hi!
I have implemented the possibility to retrieve robot comments from Gerrit. If I am not mistaken, it still needed to be added to the project.

I implemented also the related tests and they all passed. 

However, there is something I would like to discuss with you. In the json file created for the tests ("robotcomments.json"), I had to change the fields robotId and robotRunId to robot_id and robot_run_id, respectively. If left in their original formulation, Gson does not recognize them. 

This does not match the documentation of the Gerrit REST api, where they are reported as robotId and robotRunId.

Investigating the reason behind this, I found that the cause is likely to be the field naming policy implemented in GsonFactory. 

It is probably possible to act on this, but it might require a major change. So, before taking any action I prefer to point this out to you 😄 

Thank you!