### PR TITLE
Added getAssignee

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/GerritApiImpl.java
@@ -77,7 +77,8 @@ public class GerritApiImpl extends GerritApi.NotImplemented implements GerritRes
                     new AddReviewerResultParser(gerritRestClient.getGson()),
                     new ReviewResultParser(gerritRestClient.getGson()),
                     new CommitInfoParser(gerritRestClient.getGson()),
-                    new HashtagsParser(gerritRestClient.getGson()));
+                    new HashtagsParser(gerritRestClient.getGson()),
+                    new AccountsParser(gerritRestClient.getGson()));
         }
     });
 

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
@@ -36,6 +36,7 @@ import com.google.gerrit.extensions.restapi.RestApiException;
 import com.google.gerrit.extensions.restapi.Url;
 import com.google.gson.JsonElement;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import com.urswolfer.gerrit.client.rest.http.accounts.AccountsParser;
 import com.urswolfer.gerrit.client.rest.http.config.ServerRestClient;
 import com.urswolfer.gerrit.client.rest.http.util.UrlUtils;
 
@@ -61,6 +62,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
     private final EditInfoParser editInfoParser;
     private final CommitInfoParser commitInfoParser;
     private final HashtagsParser hashtagsParser;
+    private final AccountsParser accountsParser;
     private final String id;
     private final ServerRestClient serverRestClient;
 
@@ -79,6 +81,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
                                EditInfoParser editInfoParser,
                                CommitInfoParser commitInfoParser,
                                HashtagsParser hashtagsParser,
+                               AccountsParser accountsParser,
                                String id) {
         this.gerritRestClient = gerritRestClient;
         this.changesRestClient = changesRestClient;
@@ -95,6 +98,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
         this.editInfoParser = editInfoParser;
         this.commitInfoParser = commitInfoParser;
         this.hashtagsParser = hashtagsParser;
+        this.accountsParser = accountsParser;
         this.id = id;
         this.serverRestClient = new ServerRestClient(gerritRestClient);
     }
@@ -182,6 +186,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
             editInfoParser,
             commitInfoParser,
             hashtagsParser,
+            accountsParser,
             id);
     }
 
@@ -303,6 +308,20 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
     }
 
     @Override
+    public Set<String> getHashtags() throws RestApiException {
+        String request = getRequestPath() + "/hashtags";
+        JsonElement jsonElement = gerritRestClient.getRequest(request);
+        return hashtagsParser.parseHashtags(jsonElement);
+    }
+
+    @Override
+    public AccountInfo getAssignee() throws RestApiException {
+        String request = getRequestPath() + "/assignee";
+        JsonElement jsonElement = gerritRestClient.getRequest(request);
+        return accountsParser.parseAccountInfo(jsonElement);
+    }
+
+    @Override
     public ChangeInfo check() throws RestApiException {
         String request = getRequestPath() + "/check";
         JsonElement jsonElement = gerritRestClient.getRequest(request);
@@ -349,13 +368,6 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
         String request = getRequestPath() + "/messages";
         JsonElement jsonElement = gerritRestClient.getRequest(request);
         return messagesParser.parseChangeMessageInfos(jsonElement);
-    }
-
-    @Override
-    public Set<String> getHashtags() throws RestApiException {
-        String request = getRequestPath() + "/hashtags";
-        JsonElement jsonElement = gerritRestClient.getRequest(request);
-        return hashtagsParser.parseHashtags(jsonElement);
     }
 
     protected String getRequestPath() {

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClient.java
@@ -26,6 +26,7 @@ import com.google.gerrit.extensions.restapi.RestApiException;
 import com.google.gerrit.extensions.restapi.Url;
 import com.google.gson.JsonElement;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import com.urswolfer.gerrit.client.rest.http.accounts.AccountsParser;
 import com.urswolfer.gerrit.client.rest.http.util.UrlUtils;
 
 import java.util.List;
@@ -49,6 +50,7 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
     private final ReviewResultParser reviewResultParser;
     private final CommitInfoParser commitInfoParser;
     private final HashtagsParser hashtagsParser;
+    private final AccountsParser accountsParser;
 
     public ChangesRestClient(GerritRestClient gerritRestClient,
                              ChangesParser changesParser,
@@ -63,7 +65,8 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
                              AddReviewerResultParser addReviewerResultParser,
                              ReviewResultParser reviewResultParser,
                              CommitInfoParser commitInfoParser,
-                             HashtagsParser hashtagsParser) {
+                             HashtagsParser hashtagsParser,
+                             AccountsParser accountsParser) {
         this.gerritRestClient = gerritRestClient;
         this.changesParser = changesParser;
         this.commentsParser = commentsParser;
@@ -78,6 +81,7 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
         this.reviewResultParser = reviewResultParser;
         this.commitInfoParser = commitInfoParser;
         this.hashtagsParser = hashtagsParser;
+        this.accountsParser = accountsParser;
     }
 
     @Override
@@ -133,7 +137,8 @@ public class ChangesRestClient extends Changes.NotImplemented implements Changes
     public ChangeApi id(String id) throws RestApiException {
         return new ChangeApiRestClient(gerritRestClient, this, changesParser, commentsParser,
             messagesParser, includedInInfoParser, fileInfoParser, diffInfoParser, addReviewerResultParser,
-            reviewResultParser, suggestedReviewerInfoParser, reviewerInfoParser, editInfoParser, commitInfoParser, hashtagsParser, id);
+            reviewResultParser, suggestedReviewerInfoParser, reviewerInfoParser, editInfoParser, commitInfoParser,
+            hashtagsParser, accountsParser, id);
     }
 
     @Override

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
@@ -25,6 +25,7 @@ import com.google.gerrit.extensions.common.*;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import com.urswolfer.gerrit.client.rest.http.accounts.AccountsParser;
 import com.urswolfer.gerrit.client.rest.http.common.GerritRestClientBuilder;
 import org.easymock.EasyMock;
 import org.testng.annotations.Test;
@@ -50,7 +51,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
             null, null, null, null, null,
-            null, reviewerInfoParser, null, null, null,
+            null, reviewerInfoParser, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<ReviewerInfo> listReviewers = changeApiRestClient.listReviewers();
@@ -259,7 +260,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
             null, null, null, null, null,
-            null, suggestedReviewerInfoParser, null, null, null, null,
+            null, suggestedReviewerInfoParser, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<SuggestedReviewerInfo> suggestedReviewerInfos = changeApiRestClient.suggestReviewers("J").get();
@@ -283,7 +284,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
             null, null, null, null, null,
-            null, suggestedReviewerInfoParser, null, null, null, null,
+            null, suggestedReviewerInfoParser, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<SuggestedReviewerInfo> suggestedReviewerInfos = changeApiRestClient.suggestReviewers("J").withLimit(5).get();
@@ -306,7 +307,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
             null, null, null, null, null,
-            null, null, null, null, null, null,
+            null, null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         ChangeInfo changeInfo = changeApiRestClient.check();
@@ -329,7 +330,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
             null, includedInInfoParser, null, null, null,
-            null, null, null, null, null, null,
+            null, null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         IncludedInInfo includedInInfo = changeApiRestClient.includedIn();
@@ -359,7 +360,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
             null,null, null, null, null,
-            null, null, null, null, null, null,
+            null, null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         ChangeInfo changeInfo = changeApiRestClient.check(fixInput);
@@ -382,7 +383,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, commentsParser,
             null, null, null, null, null,
-            null, null, null, null, null, null,
+            null, null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         Map<String, List<CommentInfo>> commentInfos = changeApiRestClient.comments();
@@ -405,7 +406,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, commentsParser,
             null, null, null, null, null,
-            null, null, null, null, null, null,
+            null, null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         Map<String, List<RobotCommentInfo>> robotCommentInfos = changeApiRestClient.robotComments();
@@ -428,7 +429,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
             messagesParser, null, null, null, null,
-            null, null, null, null, null, null,
+            null, null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<ChangeMessageInfo> messageInfos = changeApiRestClient.messages();
@@ -451,7 +452,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
             null, null, null, null, null,
-            null, null, null, null, null, hashtagsParser,
+            null, null, null, null, null, hashtagsParser, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         Set<String> hashtags = changeApiRestClient.getHashtags();
@@ -474,13 +475,36 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
             null, null, null, null, null,
-            null, null, null, editInfoParser, null, null,
+            null, null, null, editInfoParser, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         EditInfo editInfo = changeApiRestClient.getEdit();
         Truth.assertThat(editInfo).isSameAs(expectedEditInfo);
 
         EasyMock.verify(gerritRestClient);
+    }
+
+    @Test
+    public void testGetAssignee() throws Exception {
+        JsonElement jsonElement = EasyMock.createMock(JsonElement.class);
+        GerritRestClient gerritRestClient = new GerritRestClientBuilder()
+            .expectGet("/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/assignee", jsonElement)
+            .get();
+
+        AccountInfo expectedAssignee = new AccountInfo(null);
+        AccountsParser accountsParser = EasyMock.createMock(AccountsParser.class);
+        EasyMock.expect(accountsParser.parseAccountInfo(jsonElement)).andReturn(expectedAssignee).once();
+        EasyMock.replay(accountsParser);
+
+        ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null,
+            null, null, null, null, null,
+            null, null, null, null, null, null,
+             accountsParser, "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+
+        AccountInfo assigneeInfo = changeApiRestClient.getAssignee();
+
+        Truth.assertThat(assigneeInfo).isSameAs(expectedAssignee);
+        EasyMock.verify(gerritRestClient, accountsParser);
     }
 
     @Test
@@ -496,7 +520,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
             null, null,  null, null, null,
-            null, null, null, null, null, null,
+            null, null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         EnumSet<ListChangesOption> options = EnumSet.of(ListChangesOption.LABELS, ListChangesOption.DETAILED_LABELS);
         ChangeInfo result = changeApiRestClient.get(options);
@@ -540,7 +564,8 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
             null, null,  null, null, null,
-            null, null, null, null, null, null, expectedChangeId);
+            null, null, null, null, null, null, null,
+            expectedChangeId);
         ChangeInfo result = changeApiRestClient.get();
 
         Truth.assertThat(result).isSameAs(expectedChangeInfo);
@@ -571,7 +596,8 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null,
             null, null,  null, null, null,
-            null, null, null, null, null, null, expectedChangeId);
+            null, null, null, null, null, null, null,
+            expectedChangeId);
         ChangeInfo result = changeApiRestClient.get();
 
         Truth.assertThat(result).isSameAs(expectedChangeInfo);
@@ -591,7 +617,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null, null,
             null, null,  null, null, null,
-            null, null, null, null, null,
+            null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         ChangeInfo result = changeApiRestClient.info();
 
@@ -626,7 +652,7 @@ public class ChangeApiRestClientTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, changesParser, null, null,
             null, null, null, null, null,
-            null, null, null, null, null,
+            null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<ChangeInfo> changeInfos = changeApiRestClient.submittedTogether();
@@ -663,6 +689,7 @@ public class ChangeApiRestClientTest {
                 EasyMock.createMock(AddReviewerResultParser.class),
                 EasyMock.createMock(ReviewResultParser.class),
                 EasyMock.createMock(CommitInfoParser.class),
-                EasyMock.createMock(HashtagsParser.class));
+                EasyMock.createMock(HashtagsParser.class),
+                EasyMock.createMock(AccountsParser.class));
     }
 }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangesRestClientTest.java
@@ -93,7 +93,7 @@ public class ChangesRestClientTest {
 
         ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null,
             null, null, null, null, null,
-            null, null, null, null, null);
+            null, null, null, null, null, null);
 
         Changes.QueryRequest queryRequest = changes.query();
         testCase.queryParameter.apply(queryRequest).get();
@@ -111,7 +111,7 @@ public class ChangesRestClientTest {
 
         ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null,
             null, null, null, null, null,
-            null, null, null, null, null);
+            null, null, null, null, null, null);
         changesRestClient.query("is:open").get();
 
         EasyMock.verify(gerritRestClient);
@@ -125,7 +125,7 @@ public class ChangesRestClientTest {
 
         ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null,
             null, null, null, null, null,
-            null, null, null, null, null);
+            null, null, null, null, null, null);
 
         ChangeApi changeApi = changesRestClient.id(123);
 
@@ -140,7 +140,7 @@ public class ChangesRestClientTest {
 
         ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null,
             null, null, null, null, null,
-            null, null, null, null, null);
+            null, null, null, null, null, null);
 
         ChangeApi changeApi = changesRestClient.id("packages/test", 123);
 
@@ -155,7 +155,7 @@ public class ChangesRestClientTest {
 
         ChangesRestClient changesRestClient = new ChangesRestClient(gerritRestClient, changesParser, commentsParser, null,
             null,  null, null, null, null,
-            null, null, null, null, null);
+            null, null, null, null, null, null);
 
         ChangeApi changeApi = changesRestClient.id("packages/test", "master", "Ieabd72e73f3da0df90fd6e8cba8f6c5dd7d120df");
 
@@ -170,7 +170,7 @@ public class ChangesRestClientTest {
 
         ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser,null, null,
             null, null, null, null, null,
-            null, null, null, null, null);
+            null, null, null, null, null, null);
 
         changes.query().get();
 
@@ -191,7 +191,7 @@ public class ChangesRestClientTest {
 
         ChangesRestClient changes = new ChangesRestClient(gerritRestClient, changesParser, null, null,
             null, null, null, null, null,
-            null, null, null, null, null);
+            null, null, null, null, null, null);
 
         ChangeApi changeApi = changes.create(changeInput);
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/DraftsApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/DraftsApiRestClientTest.java
@@ -45,8 +45,8 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
             .get();
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, commentsParser, null,
-            null, null, null, null,null, null,
-            null, null, null, null,
+            null, null, null, null, null, null,
+            null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, commentsParser, null, null, null, null, revisionId);
 
@@ -67,7 +67,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
             null, null, null, null, null,
-            null, null, null,null, null,
+            null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,
@@ -92,7 +92,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
             null, null, null, null, null,
-            null, null, null, null, null,
+            null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,
@@ -114,7 +114,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
 
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
             null, null,null, null, null,
-            null, null, null, null, null,
+            null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/HashtagsParserTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/HashtagsParserTest.java
@@ -21,7 +21,6 @@ import com.urswolfer.gerrit.client.rest.http.common.AbstractParserTest;
 import com.urswolfer.gerrit.client.rest.http.common.GerritAssert;
 import org.testng.annotations.Test;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerApiRestClientTest.java
@@ -43,7 +43,7 @@ public class ReviewerApiRestClientTest extends AbstractParserTest {
             .get();
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
             null, null, null, null, null,
-            null, null, null, null, null,
+            null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         ReviewerApiRestClient reviewerApiRestClient = new ReviewerApiRestClient(gerritRestClient, changeApiRestClient, ACCOUNT_ID);
         Map<String, Short> votes = reviewerApiRestClient.votes();
@@ -59,7 +59,7 @@ public class ReviewerApiRestClientTest extends AbstractParserTest {
             .expectDelete("/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/reviewers/" + ACCOUNT_ID + "/votes/" + LABEL)
             .get();
         ChangeApiRestClient changeApiRestClient = new ChangeApiRestClient(gerritRestClient, null, null, null, null,
-            null, null, null, null, null,
+            null, null, null, null, null, null,
             null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         ReviewerApiRestClient reviewerApiRestClient = new ReviewerApiRestClient(gerritRestClient, changeApiRestClient, ACCOUNT_ID);

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
@@ -26,6 +26,7 @@ import com.google.gerrit.extensions.common.TestSubmitRuleInput;
 import com.google.gerrit.extensions.restapi.BinaryResult;
 import com.google.gson.JsonElement;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import com.urswolfer.gerrit.client.rest.http.accounts.AccountsParser;
 import com.urswolfer.gerrit.client.rest.http.common.AbstractParserTest;
 import com.urswolfer.gerrit.client.rest.http.common.GerritRestClientBuilder;
 import org.apache.commons.codec.binary.Base64;
@@ -393,9 +394,10 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
         ReviewResultParser reviewResultParser = EasyMock.createMock(ReviewResultParser.class);
         CommitInfoParser commitInfoParser = EasyMock.createMock(CommitInfoParser.class);
         HashtagsParser hashtagsParser = EasyMock.createMock(HashtagsParser.class);
+        AccountsParser accountsParser = EasyMock.createMock(AccountsParser.class);
         return new ChangesRestClient(gerritRestClient, changesParser, commentsParser, messagesParser,
             includedInInfoParser, fileInfoParser, diffInfoParser, null, reviewerInfoParser, editInfoParser,
-            addReviewerResultParser, reviewResultParser, commitInfoParser, hashtagsParser);
+            addReviewerResultParser, reviewResultParser, commitInfoParser, hashtagsParser, accountsParser);
     }
 
     private ChangesRestClient getChangesRestClient(GerritRestClient gerritRestClient, CommentsParser commentsParser) {
@@ -413,7 +415,8 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
                 EasyMock.createMock(AddReviewerResultParser.class),
                 EasyMock.createMock(ReviewResultParser.class),
                 EasyMock.createMock(CommitInfoParser.class),
-                EasyMock.createMock(HashtagsParser.class));
+                EasyMock.createMock(HashtagsParser.class),
+                EasyMock.createMock(AccountsParser.class));
     }
 
     private static RevisionApiTestCase withRevision(String revision) {


### PR DESCRIPTION
Hi! I added the _getAssignee( )_ function in the _ChangeApiRestClient_ class. 

While I was working on it, I did some small refactoring as well. I did not open a separate PR for those since they are quite small changes. They are the following:

- Added blank space between comma and parameter in _DraftApiRestClientTest_.
- Removed unused import in _HashtagParserTest_.
- Moved the method _getHashtags()_ in _ChangeApiRestClient_ to follow the order of the implemented interface _ChangeApi_.