### PR TITLE
Avoid spamming Gerrit when using GitHub/OAuth authentication

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/LoginCache.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/LoginCache.java
@@ -18,7 +18,10 @@ package com.urswolfer.gerrit.client.rest.http;
 
 import com.google.common.base.Optional;
 import com.urswolfer.gerrit.client.rest.GerritAuthData;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
 
 /**
  * @author Urs Wolfer
@@ -26,6 +29,7 @@ import org.apache.http.impl.client.BasicCookieStore;
 public class LoginCache {
     private final BasicCookieStore cookieStore;
     private final GerritAuthData authData;
+    private boolean githubOAuthDetected;
 
     private Optional<String> gerritAuthOptional = Optional.absent();
     // remember when host does not support gerrit-auth login method so we don't have to try again
@@ -57,6 +61,15 @@ public class LoginCache {
         gerritAuthOptional = Optional.absent();
         hostSupportsGerritAuth = true;
         cookieStore.clear();
+    }
+
+    public boolean isGithubOAuthDetected() {
+        return githubOAuthDetected;
+    }
+
+    public boolean isGitHubOAuthRequested(HttpContext loginContext) {
+        HttpUriRequest lastRequest = (HttpUriRequest) loginContext.getAttribute(HttpCoreContext.HTTP_REQUEST);
+        return githubOAuthDetected || (githubOAuthDetected = (lastRequest != null && lastRequest.getURI().getPath().contains("github-plugin")));
     }
 
     /**

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/GitHubOAuthLoginSimulationServlet.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/GitHubOAuthLoginSimulationServlet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2015 Urs Wolfer
+ * Copyright 2020 Luca Milanesio
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,21 +28,23 @@ import java.io.IOException;
 
 
 /**
- * @author Urs Wolfer
+ * @author Luca Milanesio
  */
-public class LoginSimulationServlet extends HttpServlet {
-    public static final String INDEX_HTML = "src/test/resources/com/urswolfer/gerrit/client/rest/http/login/index.html";
+public class GitHubOAuthLoginSimulationServlet extends HttpServlet {
+    private static final String OAUTH_SCOPE_PATH = "/plugins/github-plugin/static/scope.html";
 
     /**
-     * Only handle case when no "Authorization" header is sent. When "Authorization" header is sent,
-     * leave it to GerritRestClientTest#basicAuth.
+     * Always redirect to the OAuth scope selection, simulating the GitHub/OAuth authentication
+     * behaviour.
      */
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        if (req.getHeader("Authorization") != null) {
-            return;
-        }
+        resp.sendRedirect(OAUTH_SCOPE_PATH);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         resp.addCookie(new Cookie("GerritAccount", "value"));
-        ByteStreams.copy(new FileInputStream(INDEX_HTML), resp.getOutputStream());
+        ByteStreams.copy(new FileInputStream(LoginSimulationServlet.INDEX_HTML), resp.getOutputStream());
     }
 }


### PR DESCRIPTION
When Gerrit is configured with a GitHub/OAuth auth type,
the form authentication is technically available but not
in a way that can be automatically used by the REST Client.

GitHub may require additional authentication verification
methods such as 2FA that are incompatible with a batch use
by the Gerrit REST client library.

Detect the OAuth handshake by looking at the redirection
path containing the github plugin scope selection and
avoid attempting the form authentication mechanism again.

Closes #107