### PR TITLE
Added reviewersList() in RevisionApiRestClient

### DIFF
--- a/src/main/java/com/google/gerrit/extensions/api/changes/RevisionApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/RevisionApi.java
@@ -94,6 +94,8 @@ public interface RevisionApi {
 
   List<RobotCommentInfo> robotCommentsAsList() throws RestApiException;
 
+  List<ReviewerInfo> listReviewers() throws RestApiException;
+
   /**
    * Applies the indicated fix by creating a new change edit or integrating the fix with the
    * existing change edit. If no change edit exists before this call, the fix must refer to the
@@ -282,6 +284,11 @@ public interface RevisionApi {
 
     @Override
     public List<RobotCommentInfo> robotCommentsAsList() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public List<ReviewerInfo> listReviewers() throws RestApiException {
       throw new NotImplementedException();
     }
 

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
@@ -120,7 +120,7 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
 
     @Override
     public RevisionApi revision(String id) throws RestApiException {
-        return new RevisionApiRestClient(gerritRestClient, this, commentsParser, fileInfoParser, diffInfoParser, reviewResultParser, commitInfoParser, id);
+        return new RevisionApiRestClient(gerritRestClient, this, commentsParser, fileInfoParser, diffInfoParser, reviewResultParser, commitInfoParser, reviewerInfoParser, id);
     }
 
     @Override

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerInfoParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerInfoParser.java
@@ -38,6 +38,7 @@ public class ReviewerInfoParser {
     }
 
     public List<ReviewerInfo> parseReviewerInfos(JsonElement result) {
+        System.out.println("test 2");
         if (!result.isJsonArray()) {
             return Collections.singletonList(gson.fromJson(result,  ReviewerInfo.class));
         }

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerInfoParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerInfoParser.java
@@ -38,7 +38,6 @@ public class ReviewerInfoParser {
     }
 
     public List<ReviewerInfo> parseReviewerInfos(JsonElement result) {
-        System.out.println("test 2");
         if (!result.isJsonArray()) {
             return Collections.singletonList(gson.fromJson(result,  ReviewerInfo.class));
         }

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClient.java
@@ -49,6 +49,7 @@ public class RevisionApiRestClient extends RevisionApi.NotImplemented implements
     private final DiffInfoParser diffInfoParser;
     private final ReviewResultParser reviewResultParser;
     private final CommitInfoParser commitInfoParser;
+    private final ReviewerInfoParser reviewerInfoParser;
     private final String revision;
 
     public RevisionApiRestClient(GerritRestClient gerritRestClient,
@@ -58,6 +59,7 @@ public class RevisionApiRestClient extends RevisionApi.NotImplemented implements
                                  DiffInfoParser diffInfoParser,
                                  ReviewResultParser reviewResultParser,
                                  CommitInfoParser commitInfoParser,
+                                 ReviewerInfoParser reviewerInfoParser,
                                  String revision) {
         this.gerritRestClient = gerritRestClient;
         this.changeApiRestClient = changeApiRestClient;
@@ -66,6 +68,7 @@ public class RevisionApiRestClient extends RevisionApi.NotImplemented implements
         this.diffInfoParser = diffInfoParser;
         this.reviewResultParser = reviewResultParser;
         this.commitInfoParser = commitInfoParser;
+        this.reviewerInfoParser = reviewerInfoParser;
         this.revision = revision;
     }
 
@@ -143,6 +146,13 @@ public class RevisionApiRestClient extends RevisionApi.NotImplemented implements
     @Override
     public TreeMap<String, List<CommentInfo>> comments() throws RestApiException {
         return comments("comments");
+    }
+
+    @Override
+    public List<ReviewerInfo> listReviewers() throws RestApiException {
+        String request = getRequestPath() + "/reviewers/";
+        JsonElement jsonElement = gerritRestClient.getRequest(request);
+        return reviewerInfoParser.parseReviewerInfos(jsonElement);
     }
 
     @Override

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/DraftsApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/DraftsApiRestClientTest.java
@@ -48,7 +48,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
             null, null, null, null, null, null,
             null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
-        RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, commentsParser, null, null, null, null, revisionId);
+        RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, commentsParser, null, null, null, null, null, revisionId);
 
         CommentInfo commentInfo = revisionApiRestClient.draft(draftId).get();
 
@@ -69,7 +69,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
             null, null, null, null, null,
             null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
-        RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
+        RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,
             revisionApiRestClient, null, expectedCommentInfo);
 
@@ -94,7 +94,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
             null, null, null, null, null,
             null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
-        RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
+        RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,
             revisionApiRestClient, commentsParser, "89233d9c_56013406");
 
@@ -116,7 +116,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
             null, null,null, null, null,
             null, null, null, null, null, null,
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
-        RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, revisionId);
+        RevisionApiRestClient revisionApiRestClient = new RevisionApiRestClient(gerritRestClient, changeApiRestClient, null, null, null, null, null, null, revisionId);
         DraftApiRestClient draftApiRestClient = new DraftApiRestClient(gerritRestClient, changeApiRestClient,
             revisionApiRestClient, null, "89233d9c_56013406");
 


### PR DESCRIPTION
Hi! 

I added the possibility to retrieve a list of reviewers for a specific revision. Apparently this functionality is supported by the Rest Gerrit API [(here)](https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#revision-reviewer-endpoints). 

However, I had to update the _RevisionApi_ class. I hope this is not an issue since the Gerrit API seems to have been changed as well. 

Also, I might be totally wrong, but I noticed that _RevisionReviewerApi reviewer(String id)_ seems to not be supported anymore. 
I did not touch it yet, but shall we consider to remove it? or might it be useful to support older versions of Gerrit? 