### PR TITLE
Modify the problem that the group name cannot be obtained

### DIFF
--- a/src/main/java/com/google/gerrit/extensions/api/groups/Groups.java
+++ b/src/main/java/com/google/gerrit/extensions/api/groups/Groups.java
@@ -85,12 +85,12 @@ public interface Groups {
 
     public List<GroupInfo> get() throws RestApiException {
       Map<String, GroupInfo> map = getAsMap();
-      List<GroupInfo> result = new ArrayList<>(map.size());
-      for (Map.Entry<String, GroupInfo> e : map.entrySet()) {
-        // ListGroups "helpfully" nulls out names when converting to a map.
-        e.getValue().name = e.getKey();
-        result.add(e.getValue());
-      }
+      List<GroupInfo> result = new ArrayList<>(map.values());
+//      for (Map.Entry<String, GroupInfo> e : map.entrySet()) {
+//        // ListGroups "helpfully" nulls out names when converting to a map.
+//        e.getValue().name = e.getKey();
+//        result.add(e.getValue());
+//      }
       return Collections.unmodifiableList(result);
     }
 

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsParser.java
@@ -23,10 +23,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.SortedMap;
+import java.util.*;
 
 /**
  * @author Shawn Stafford
@@ -55,6 +52,11 @@ public class GroupsParser {
             return gson.fromJson(result, GROUP_LIST_TYPE);
         } else {
             SortedMap<String, GroupInfo> map = gson.fromJson(result, GROUP_MAP_TYPE);
+            if (map != null && !map.isEmpty()) {
+                for (Map.Entry<String, GroupInfo> groupInfoEntry : map.entrySet()) {
+                    groupInfoEntry.getValue().name = groupInfoEntry.getKey();
+                }
+            }
             return new ArrayList<GroupInfo>(map.values());
         }
     }


### PR DESCRIPTION
In use, I found that the name of the group could not be obtained. After checking the source code, I found that in the class Groups#ListRequest, id was used to assign a value to name