### PR TITLE
implemented revertSubmission

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
@@ -161,6 +161,21 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
     }
 
     @Override
+    public RevertSubmissionInfo revertSubmission() throws RestApiException {
+        return revertSubmission(new RevertInput());
+    }
+
+    @Override
+    public RevertSubmissionInfo revertSubmission(RevertInput in) throws RestApiException{
+        String request = getRequestPath() + "/revert_submission";
+        String json = gerritRestClient.getGson().toJson(in);
+        JsonElement revertedChanges = gerritRestClient.postRequest(request, json);
+        RevertSubmissionInfo revertSubmissionInfo = new RevertSubmissionInfo();
+        revertSubmissionInfo.revertChanges = changeInfosParser.parseChangeInfos(revertedChanges);
+        return revertSubmissionInfo;
+    }
+
+    @Override
     public void publish() throws RestApiException {
         String request = getRequestPath() + "/publish";
         gerritRestClient.postRequest(request);

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
@@ -246,6 +246,32 @@ public class ChangeApiRestClientTest {
     }
 
     @Test
+    public void testRevertSubmission() throws Exception {
+        GerritRestClient gerritRestClient = getGerritRestClient(
+            "/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/revert_submission",
+            "{\"notify\":\"ALL\"}"
+        );
+        ChangesRestClient changesRestClient = getChangesRestClient(gerritRestClient);
+        changesRestClient.id("myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940").revertSubmission();
+
+        EasyMock.verify(gerritRestClient);
+    }
+
+    @Test
+    public void testRevertSubmissionWithMessage() throws Exception {
+        GerritRestClient gerritRestClient = getGerritRestClient(
+            "/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/revert_submission",
+            "{\"message\":\"Submission need revert.\",\"notify\":\"ALL\"}"
+        );
+        ChangesRestClient changesRestClient = getChangesRestClient(gerritRestClient);
+        RevertInput revertInput = new RevertInput();
+        revertInput.message = "Submission need revert.";
+        changesRestClient.id("myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940").revertSubmission(revertInput);
+
+        EasyMock.verify(gerritRestClient);
+    }
+
+    @Test
     public void testSuggestReviewers() throws Exception {
         JsonElement jsonElement = EasyMock.createMock(JsonElement.class);
         GerritRestClient gerritRestClient = new GerritRestClientBuilder()


### PR DESCRIPTION
Hi!

I have added the implementation of the method _revertSubmission_. Let me know if everything is ok or something needs to be changed. 

In the tests, I followed a similar implementation to the one used for the _testRevertChange_ methods. 
My understanding is that, in these methods, the fact that the entity returned is indeed correct is not checked. They only check that the post request is performed correctly.

Should we add this kind of check or the current implementation is fine? 