### PR TITLE
Correct GroupsPaser.java leaving names empty

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsParser.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.SortedMap;
+import java.util.Map;
 
 /**
  * @author Shawn Stafford
@@ -55,6 +56,9 @@ public class GroupsParser {
             return gson.fromJson(result, GROUP_LIST_TYPE);
         } else {
             SortedMap<String, GroupInfo> map = gson.fromJson(result, GROUP_MAP_TYPE);
+            for(Map.Entry<String,GroupInfo> entry : map.entrySet()){
+                entry.getValue().name = entry.getKey();
+            }
             return new ArrayList<GroupInfo>(map.values());
         }
     }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsParserTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/groups/GroupsParserTest.java
@@ -93,4 +93,11 @@ public class GroupsParserTest extends AbstractParserTest {
         List<AccountInfo> accountInfos = groupsParser.parseGroupMembers(jsonElement);
         Truth.assertThat(accountInfos).hasSize(2);
     }
+
+    @Test
+    public void testParseGroupName() throws Exception {
+        JsonElement jsonElement = getJsonElement("groups.json");
+        List<GroupInfo> groupInfos = groupsParser.parseGroupInfos(jsonElement);
+        Truth.assertThat(groupInfos.get(0).name).isEqualTo("Administrators");
+    }
 }


### PR DESCRIPTION
When returning Lists of GroupInfo the name field
was left null update is to parse this out of the
returned map so that group names can be queried.