### PR TITLE
Adding enums for Access capabilities

### DIFF
--- a/src/main/java/com/google/gerrit/extensions/api/access/GlobalCapabilities.java
+++ b/src/main/java/com/google/gerrit/extensions/api/access/GlobalCapabilities.java
@@ -1,0 +1,52 @@
+// Copyright (C) 2016 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.access;
+
+public enum GlobalCapabilities {
+  ACCESS_DATABASE("access database"),
+  ADMINISTRATE_SERVER("administrate server"),
+  BATCH_CHANGES_LIMIT("batch changes limit"),
+  CREATE_ACCOUNT("create account"),
+  CREATE_GROUP("create group"),
+  CREATE_PROJECT("create project"),
+  EMAIL_REVIEWERS("email reviewers"),
+  FLUSH_CACHES("flush caches"),
+  KILL_TASK("kill task"),
+  MAINTAIN_SERVER("maintain server"),
+  MODIFY_ACCOUNT("modify account"),
+  PRIORITY("priority"),
+  QUERY_LIMIT("query limit"),
+  READ_AS("read as"),
+  RUN_AS("run as"),
+  RUN_GARBAGE_COLLECTION("run garbage collection"),
+  STREAM_EVENTS("stream events"),
+  VIEW_ACCESS("view access"),
+  VIEW_ALL_ACCOUNTS("view all accounts"),
+  VIEW_CACHES("view caches"),
+  VIEW_CONNECTIONS("view connections"),
+  VIEW_PLUGINS("view plugins"),
+  VIEW_QUEUE("view queue");
+
+  final private String capability;
+
+  GlobalCapabilities(String label) {
+    this.capability = label;
+  }
+
+  @Override
+  public String toString() {
+    return capability;
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/api/access/ReferenceCapabilities.java
+++ b/src/main/java/com/google/gerrit/extensions/api/access/ReferenceCapabilities.java
@@ -1,0 +1,54 @@
+// Copyright (C) 2016 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.access;
+
+public enum ReferenceCapabilities {
+  ABANDON("abandon"),
+  CREATE_REFERENCE("create reference"),
+  DELETE_REFERENCE("delete reference"),
+  FORGE_AUTHOR("forge author"),
+  FORGE_COMMITTER("forge committer"),
+  FORGE_SERVER("forge server"),
+  OWNER("owner"),
+  PUSH("push"),
+  DIRECT_PUSH("direct push"),
+  ADD_PATCH_SET("add patch set"),
+  UPLOAD_TO_CODE_REVIEW("upload to code review"),
+  PUSH_MERGE_COMMITS("push merge commits"),
+  CREATE_ANNOTATED_TAG("create annotated tag"),
+  CREATE_SIGNED_TAG("create signed tag"),
+  READ("read"),
+  REBASE("rebase"),
+  REVIEW_LABELS("review label"),
+  SUBMIT("submit"),
+  SUBMIT_ON_BEHALF_OF("submit (on behalf of)"),
+  VIEW_PRIVATE_CHANGES("view private changes"),
+  DELETE_OWN_CHANGES("delete own changes"),
+  DELETE_CHANGES("delete changes"),
+  EDIT_TOPIC_NAME("edit topic name"),
+  EDIT_HASHTAGS("edit hashtags"),
+  EDIT_ASSIGNEE("edit assignee");
+
+  final private String capability;
+
+  ReferenceCapabilities(String label) {
+    this.capability = label;
+  }
+
+  @Override
+  public String toString() {
+    return capability;
+  }
+}


### PR DESCRIPTION
Creating an enum set for capabilities

Separated Global from ref access 
Idea being to move these into parsed objects for input and response from api.
or at minimum a immutable set strings for what are static permissions on gerrit.

e.g:
        permissionInfo.rules.put("global:Registered-Users", new PermissionRuleInfo(PermissionRuleInfo.Action.ALLOW, false));
        accessSectionInfo.permissions.put(RefCapabilities.READ, permissionInfo);
        projectAccessInput.add.put("refs/tags/*", accessSectionInfo);


not sure best place to put these at present so feedback would be greatly appreciated.

Path through the api to set access rules little painful when doing it in bulk, this is kind of the start to implementing 
an AccessParser and API object with end goal of something like:

project.access().AddRule(String reference, String GroupName, Capability, PermissionRuleInfo);
project.access().RemoveRule(String reference, String GroupName, Capability, PermissionRuleInfo);

