### PR TITLE
Implementing Comment and RobotComment api

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/CommentApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/CommentApiRestClient.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013-2024 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.gerrit.extensions.api.changes.CommentApi;
+import com.google.gerrit.extensions.api.changes.DeleteCommentInput;
+import com.google.gerrit.extensions.common.CommentInfo;
+import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gson.JsonElement;
+import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import com.urswolfer.gerrit.client.rest.http.changes.parsers.CommentsParser;
+
+public class CommentApiRestClient extends CommentApi.NotImplemented implements CommentApi {
+
+    private final GerritRestClient gerritRestClient;
+    private final RevisionApiRestClient revisionApiRestClient;
+    private final CommentsParser commentsParser;
+    private final String id;
+
+    public CommentApiRestClient(GerritRestClient gerritRestClient,
+                              RevisionApiRestClient revisionApiRestClient,
+                              CommentsParser commentsParser,
+                              String id) {
+        this.gerritRestClient = gerritRestClient;
+        this.revisionApiRestClient = revisionApiRestClient;
+        this.commentsParser = commentsParser;
+        this.id = id;
+    }
+
+    @Override
+    public CommentInfo get() throws RestApiException {
+        JsonElement response = gerritRestClient.getRequest(getRequestPath());
+        return commentsParser.parseSingleCommentInfo(response);
+    }
+
+    @Override
+    public CommentInfo delete(DeleteCommentInput input) throws RestApiException {
+        String body = gerritRestClient.getGson().toJson(input);
+        JsonElement response = gerritRestClient.postRequest(getRequestPath() + "/delete", body);
+        return commentsParser.parseSingleCommentInfo(response);
+    }
+
+    protected String getRequestPath() {
+        return revisionApiRestClient.getRequestPath() + "/comments/" + id;
+    }
+}

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClient.java
@@ -195,6 +195,16 @@ public class RevisionApiRestClient extends RevisionApi.NotImplemented implements
         return new DraftApiRestClient(gerritRestClient, changeApiRestClient, this, commentsParser, id);
     }
 
+    @Override
+    public CommentApi comment(String id) throws RestApiException {
+        return new CommentApiRestClient(gerritRestClient, this, commentsParser, id);
+    }
+
+    @Override
+    public RobotCommentApi robotComment(String id) throws RestApiException {
+        return new RobotCommentApiRestClient(gerritRestClient, this, commentsParser, id);
+    }
+
 
     @Override
     public Map<String, FileInfo> files() throws RestApiException {

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentApiRestClient.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2024 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.gerrit.extensions.api.changes.RobotCommentApi;
+import com.google.gerrit.extensions.common.RobotCommentInfo;
+import com.google.gerrit.extensions.restapi.RestApiException;
+import com.google.gson.JsonElement;
+import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import com.urswolfer.gerrit.client.rest.http.changes.parsers.CommentsParser;
+
+public class RobotCommentApiRestClient extends RobotCommentApi.NotImplemented implements RobotCommentApi {
+
+    private final GerritRestClient gerritRestClient;
+    private final RevisionApiRestClient revisionApiRestClient;
+    private final CommentsParser commentsParser;
+    private final String id;
+
+    public RobotCommentApiRestClient(GerritRestClient gerritRestClient,
+                                     RevisionApiRestClient revisionApiRestClient,
+                                     CommentsParser commentsParser,
+                                     String id) {
+        this.gerritRestClient = gerritRestClient;
+        this.revisionApiRestClient = revisionApiRestClient;
+        this.commentsParser = commentsParser;
+        this.id = id;
+    }
+
+    @Override
+    public RobotCommentInfo get() throws RestApiException {
+        JsonElement response = gerritRestClient.getRequest(getRequestPath());
+        return commentsParser.parseSingleRobotCommentInfo(response);
+    }
+
+    protected String getRequestPath() {
+        return revisionApiRestClient.getRequestPath() + "/robotcomments/" + id;
+    }
+}

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/parsers/CommentsParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/parsers/CommentsParser.java
@@ -22,7 +22,6 @@ import com.google.gerrit.extensions.common.CommentInfo;
 import com.google.gerrit.extensions.common.RobotCommentInfo;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 
 import java.lang.reflect.Type;
 import java.util.List;
@@ -49,7 +48,7 @@ public class CommentsParser {
         return gson.fromJson(result, COMMENT_TYPE);
     }
 
-    public CommentInfo parseSingleCommentInfo(JsonObject result) {
+    public CommentInfo parseSingleCommentInfo(JsonElement result) {
         return gson.fromJson(result, CommentInfo.class);
     }
 
@@ -57,7 +56,7 @@ public class CommentsParser {
         return gson.fromJson(result, ROBOT_COMMENT_TYPE);
     }
 
-    public RobotCommentInfo parseSingleRobotCommentInfo(JsonObject result) {
+    public RobotCommentInfo parseSingleRobotCommentInfo(JsonElement result) {
         return gson.fromJson(result, RobotCommentInfo.class);
     }
 
@@ -65,7 +64,7 @@ public class CommentsParser {
         return gson.fromJson(result, CHANGE_MESSAGE_TYPE);
     }
 
-    public ChangeMessageInfo parseSingleChangeMessageInfo(JsonObject result) {
+    public ChangeMessageInfo parseSingleChangeMessageInfo(JsonElement result) {
         return gson.fromJson(result, ChangeMessageInfo.class);
     }
 }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/CommentApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/CommentApiRestClientTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2013-2024 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.common.truth.Truth;
+import com.google.gerrit.extensions.api.changes.DeleteCommentInput;
+import com.google.gerrit.extensions.common.CommentInfo;
+import com.google.gson.JsonElement;
+import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import com.urswolfer.gerrit.client.rest.http.changes.parsers.CommentsParser;
+import com.urswolfer.gerrit.client.rest.http.common.GerritRestClientBuilder;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+public class CommentApiRestClientTest {
+
+    private static final JsonElement MOCK_JSON_ELEMENT = EasyMock.createMock(JsonElement.class);
+    private static final String COMMENT_ID = "TvcXrmjM";
+    private static final String REVISION_ID = "ec047590bc7fb8db7ae03ebac336488bfc1c5e12";
+
+
+    @Test
+    public void testGet() throws Exception {
+        GerritRestClient gerritRestClient = new GerritRestClientBuilder()
+            .expectGet("/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/" +
+                "revisions/" + REVISION_ID + "/comments/" + COMMENT_ID, MOCK_JSON_ELEMENT)
+            .get();
+        CommentInfo commentInfo = EasyMock.createMock(CommentInfo.class);
+        CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
+        EasyMock.expect(commentsParser.parseSingleCommentInfo(MOCK_JSON_ELEMENT)).andReturn(commentInfo);
+        EasyMock.replay(commentsParser);
+
+        RevisionApiRestClient revisionApiRestClient = EasyMock.createMock(RevisionApiRestClient.class);
+        EasyMock.expect(revisionApiRestClient.getRequestPath()).andReturn(
+            "/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/revisions/" + REVISION_ID);
+        EasyMock.replay(revisionApiRestClient);
+
+        CommentApiRestClient commentApiRestClient = new CommentApiRestClient(gerritRestClient, revisionApiRestClient,
+            commentsParser, COMMENT_ID);
+
+        CommentInfo result = commentApiRestClient.get();
+
+        EasyMock.verify(gerritRestClient, commentsParser);
+        Truth.assertThat(result).isEqualTo(commentInfo);
+    }
+
+    @Test
+    public void testDelete() throws Exception {
+        GerritRestClient gerritRestClient = new GerritRestClientBuilder()
+            .expectPost("/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/" +
+                "revisions/" + REVISION_ID + "/comments/" + COMMENT_ID + "/delete",
+                "{\"reason\":\"Rejected by admin\"}",
+                MOCK_JSON_ELEMENT)
+            .expectGetGson()
+            .get();
+        CommentInfo commentInfo = EasyMock.createMock(CommentInfo.class);
+        CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
+        EasyMock.expect(commentsParser.parseSingleCommentInfo(MOCK_JSON_ELEMENT)).andReturn(commentInfo);
+        EasyMock.replay(commentsParser);
+
+        RevisionApiRestClient revisionApiRestClient = EasyMock.createMock(RevisionApiRestClient.class);
+        EasyMock.expect(revisionApiRestClient.getRequestPath()).andReturn(
+            "/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/revisions/" + REVISION_ID);
+        EasyMock.replay(revisionApiRestClient);
+
+        CommentApiRestClient commentApiRestClient = new CommentApiRestClient(gerritRestClient, revisionApiRestClient,
+            commentsParser, COMMENT_ID);
+
+        DeleteCommentInput input = new DeleteCommentInput();
+        input.reason = "Rejected by admin";
+        CommentInfo result = commentApiRestClient.delete(input);
+
+        EasyMock.verify(gerritRestClient, commentsParser);
+        Truth.assertThat(result).isEqualTo(commentInfo);
+    }
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
@@ -22,6 +22,8 @@ import com.google.gerrit.extensions.api.changes.CherryPickInput;
 import com.google.gerrit.extensions.api.changes.ReviewInput;
 import com.google.gerrit.extensions.api.changes.SubmitInput;
 import com.google.gerrit.extensions.client.SubmitType;
+import com.google.gerrit.extensions.common.CommentInfo;
+import com.google.gerrit.extensions.common.RobotCommentInfo;
 import com.google.gerrit.extensions.common.TestSubmitRuleInput;
 import com.google.gerrit.extensions.restapi.BinaryResult;
 import com.google.gson.JsonElement;
@@ -308,6 +310,21 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
     }
 
     @Test(dataProvider = "TestCases")
+    public void testGetComment(RevisionApiTestCase testCase) throws Exception {
+        JsonElement jsonElement = EasyMock.createMock(JsonElement.class);
+        GerritRestClient gerritRestClient = new GerritRestClientBuilder()
+            .expectGet(testCase.getCommentsUrl + "TvcXrmjM", jsonElement)
+            .get();
+        CommentInfo commentInfo = EasyMock.createMock(CommentInfo.class);
+        CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
+        EasyMock.expect(commentsParser.parseSingleCommentInfo(jsonElement)).andReturn(commentInfo).once();
+        EasyMock.replay(commentsParser);
+        ChangesRestClient changesRestClient = getChangesRestClient(gerritRestClient, commentsParser);
+        changesRestClient.id(CHANGE_ID).revision(testCase.revision).comment("TvcXrmjM").get();
+        EasyMock.verify(gerritRestClient, commentsParser);
+    }
+
+    @Test(dataProvider = "TestCases")
     public void testGetRobotComments(RevisionApiTestCase testCase) throws Exception {
         JsonElement jsonElement = EasyMock.createMock(JsonElement.class);
         GerritRestClient gerritRestClient = new GerritRestClientBuilder()
@@ -322,6 +339,21 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
 
         changesRestClient.id(CHANGE_ID).revision(testCase.revision).robotComments();
 
+        EasyMock.verify(gerritRestClient, commentsParser);
+    }
+
+    @Test(dataProvider = "TestCases")
+    public void testGetRobotComment(RevisionApiTestCase testCase) throws Exception {
+        JsonElement jsonElement = EasyMock.createMock(JsonElement.class);
+        GerritRestClient gerritRestClient = new GerritRestClientBuilder()
+            .expectGet(testCase.robotCommentsUrl + "TvcXrmjM", jsonElement)
+            .get();
+        RobotCommentInfo robotCommentInfo = EasyMock.createMock(RobotCommentInfo.class);
+        CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
+        EasyMock.expect(commentsParser.parseSingleRobotCommentInfo(jsonElement)).andReturn(robotCommentInfo).once();
+        EasyMock.replay(commentsParser);
+        ChangesRestClient changesRestClient = getChangesRestClient(gerritRestClient, commentsParser);
+        changesRestClient.id(CHANGE_ID).revision(testCase.revision).robotComment("TvcXrmjM").get();
         EasyMock.verify(gerritRestClient, commentsParser);
     }
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RobotCommentApiRestClientTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2013-2024 Urs Wolfer
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.urswolfer.gerrit.client.rest.http.changes;
+
+import com.google.common.truth.Truth;
+import com.google.gerrit.extensions.common.RobotCommentInfo;
+import com.google.gson.JsonElement;
+import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
+import com.urswolfer.gerrit.client.rest.http.changes.parsers.CommentsParser;
+import com.urswolfer.gerrit.client.rest.http.common.GerritRestClientBuilder;
+import org.easymock.EasyMock;
+import org.junit.Test;
+
+public class RobotCommentApiRestClientTest {
+
+    private static final JsonElement MOCK_JSON_ELEMENT = EasyMock.createMock(JsonElement.class);
+    private static final String COMMENT_ID = "TvcXrmjM";
+    private static final String REVISION_ID = "ec047590bc7fb8db7ae03ebac336488bfc1c5e12";
+
+
+    @Test
+    public void testGet() throws Exception {
+        GerritRestClient gerritRestClient = new GerritRestClientBuilder()
+            .expectGet("/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/" +
+                "revisions/" + REVISION_ID + "/robotcomments/" + COMMENT_ID, MOCK_JSON_ELEMENT)
+            .get();
+        RobotCommentInfo commentInfo = EasyMock.createMock(RobotCommentInfo.class);
+        CommentsParser commentsParser = EasyMock.createMock(CommentsParser.class);
+        EasyMock.expect(commentsParser.parseSingleRobotCommentInfo(MOCK_JSON_ELEMENT)).andReturn(commentInfo);
+        EasyMock.replay(commentsParser);
+
+        RevisionApiRestClient revisionApiRestClient = EasyMock.createMock(RevisionApiRestClient.class);
+        EasyMock.expect(revisionApiRestClient.getRequestPath()).andReturn(
+            "/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/revisions/" + REVISION_ID);
+        EasyMock.replay(revisionApiRestClient);
+
+        RobotCommentApiRestClient robotCommentApiRestClient = new RobotCommentApiRestClient(gerritRestClient,
+            revisionApiRestClient, commentsParser, COMMENT_ID);
+
+        RobotCommentInfo result = robotCommentApiRestClient.get();
+
+        EasyMock.verify(gerritRestClient, commentsParser);
+        Truth.assertThat(result).isEqualTo(commentInfo);
+    }
+}

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/parsers/CommentsParserTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/parsers/CommentsParserTest.java
@@ -25,7 +25,12 @@ import com.google.gerrit.extensions.common.ChangeMessageInfo;
 import com.google.gerrit.extensions.common.CommentInfo;
 import com.google.gerrit.extensions.common.RobotCommentInfo;
 import com.google.gson.JsonElement;
-import com.urswolfer.gerrit.client.rest.http.common.*;
+import com.urswolfer.gerrit.client.rest.http.common.AbstractParserTest;
+import com.urswolfer.gerrit.client.rest.http.common.AccountInfoBuilder;
+import com.urswolfer.gerrit.client.rest.http.common.ChangeMessageInfoBuilder;
+import com.urswolfer.gerrit.client.rest.http.common.CommentInfoBuilder;
+import com.urswolfer.gerrit.client.rest.http.common.GerritAssert;
+import com.urswolfer.gerrit.client.rest.http.common.RobotCommentInfoBuilder;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -199,6 +204,27 @@ public class CommentsParserTest extends AbstractParserTest {
     public void testParseMessageInfos() throws Exception {
         List<ChangeMessageInfo> messages = parseMessages();
         GerritAssert.assertEquals(messages, MESSAGES_INFOS);
+    }
+
+    @Test
+    public void testParseSingleCommentInfo() throws Exception {
+        JsonElement jsonElement = getJsonElement("comment.json");
+        CommentInfo result = commentsParser.parseSingleCommentInfo(jsonElement);
+        Truth.assertThat(result.id).isEqualTo("TvcXrmjM");
+        Truth.assertThat(result.path).isEqualTo(
+            "gerrit-server/src/main/java/com/google/gerrit/server/project/RefControl.java");
+        Truth.assertThat(result.line).isEqualTo(23);
+        Truth.assertThat(result.author._accountId).isEqualTo(1000096);
+    }
+
+    @Test
+    public void testParseSingleRobotCommentInfo() throws Exception {
+        JsonElement jsonElement = getJsonElement("robotcomment.json");
+        RobotCommentInfo result = commentsParser.parseSingleRobotCommentInfo(jsonElement);
+        Truth.assertThat(result.id).isEqualTo("TvcXrmjM");
+        Truth.assertThat(result.line).isEqualTo(23);
+        Truth.assertThat(result.robotId).isEqualTo("importChecker");
+        Truth.assertThat(result.robotRunId).isEqualTo("76b1375aa8626ea7149792831fe2ed85e80d9e04");
     }
 
     private SortedMap<String, List<CommentInfo>> parseComments() throws Exception {

--- a/src/test/resources/com/urswolfer/gerrit/client/rest/http/changes/parsers/comment.json
+++ b/src/test/resources/com/urswolfer/gerrit/client/rest/http/changes/parsers/comment.json
@@ -1,0 +1,13 @@
+)]}'
+{
+"id": "TvcXrmjM",
+"path": "gerrit-server/src/main/java/com/google/gerrit/server/project/RefControl.java",
+"line": 23,
+"message": "Comment removed by: Administrator; Reason: contains confidential information",
+"updated": "2013-02-26 15:40:43.986000000",
+"author": {
+"_account_id": 1000096,
+"name": "John Doe",
+"email": "john.doe@example.com"
+}
+}

--- a/src/test/resources/com/urswolfer/gerrit/client/rest/http/changes/parsers/robotcomment.json
+++ b/src/test/resources/com/urswolfer/gerrit/client/rest/http/changes/parsers/robotcomment.json
@@ -1,0 +1,14 @@
+)]}'
+{
+"id": "TvcXrmjM",
+"line": 23,
+"message": "unused import",
+"updated": "2016-02-26 15:40:43.986000000",
+"author": {
+"_account_id": 1000110,
+"name": "Code Analyzer",
+"email": "code.analyzer@example.com"
+},
+"robot_id": "importChecker",
+"robot_run_id": "76b1375aa8626ea7149792831fe2ed85e80d9e04"
+}


### PR DESCRIPTION
Adding rest Clients to implement comment and
robotcomment endpoint to return single comment
when queried and allow their deletion.
Tests added for single parser methods and
getting client from RevisionApiRestClient.