### PR TITLE
Update Maven Central badge to use img.shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ gerrit-rest-java-client
 [![Coverage Status](https://coveralls.io/repos/github/uwolfer/gerrit-rest-java-client/badge.svg?branch=master)](https://coveralls.io/github/uwolfer/gerrit-rest-java-client?branch=master)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=com.urswolfer.gerrit.client.rest%3Agerrit-rest-java-client&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=com.urswolfer.gerrit.client.rest%3Agerrit-rest-java-client)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=com.urswolfer.gerrit.client.rest%3Agerrit-rest-java-client&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=com.urswolfer.gerrit.client.rest%3Agerrit-rest-java-client)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.urswolfer.gerrit.client.rest/gerrit-rest-java-client/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.urswolfer.gerrit.client.rest/gerrit-rest-java-client)
+[![Maven Central](https://img.shields.io/maven-central/v/com.urswolfer.gerrit.client.rest/gerrit-rest-java-client.svg)](https://search.maven.org/artifact/com.urswolfer.gerrit.client.rest/gerrit-rest-java-client)
 
 Introduction
 -----------


### PR DESCRIPTION
## Summary
Updated the Maven Central badge in the README to use a more reliable and modern badge service.

## Changes
- Replaced the deprecated `maven-badges.herokuapp.com` badge with `img.shields.io` badge service
- Updated the badge link to point to the Maven Central search artifact page instead of the old badge service

## Details
The `maven-badges.herokuapp.com` service has become unreliable and is no longer actively maintained. This change migrates to `img.shields.io`, which is a widely-used, actively-maintained badge service that provides better uptime and more consistent functionality. The badge will now display the latest version of the gerrit-rest-java-client artifact from Maven Central.

https://claude.ai/code/session_01P8xg4FazLo2AW5jQ8qU22M