### PR TITLE
Migrate SonarCloud integration to Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
@@ -32,3 +34,9 @@ jobs:
         CI_BRANCH: ${{ github.head_ref || github.ref_name }}
         CI_PULL_REQUEST: ${{ github.event.pull_request.number }}
       run: mvn -B jacoco:report coveralls:report -DrepoToken=$COVERALLS_REPO_TOKEN
+    - name: Publish analysis to SonarCloud
+      if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      run: mvn -B jacoco:report org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,9 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.min.version>8</jdk.min.version>
     <jetty.version>8.2.0.v20160908</jetty.version>
+    <sonar.organization>uwolfer-github</sonar.organization>
+    <sonar.projectKey>com.urswolfer.gerrit.client.rest:gerrit-rest-java-client</sonar.projectKey>
+    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
## Summary
This PR integrates SonarCloud code quality analysis into the CI/CD pipeline to enable automated code quality scanning and reporting.

## Key Changes
- **GitHub Actions Workflow**: Updated `build.yml` to include SonarCloud analysis step
  - Added `fetch-depth: 0` to checkout action to ensure full git history is available for analysis
  - Added new step to publish analysis results to SonarCloud after test coverage reporting
  - Configured to run on push events and pull requests from the same repository (with security check to prevent running on external PRs)
  
- **Maven Configuration**: Added SonarCloud properties to `pom.xml`
  - Configured SonarCloud organization: `uwolfer-github`
  - Set project key for identification: `com.urswolfer.gerrit.client.rest:gerrit-rest-java-client`
  - Configured SonarCloud host URL: `https://sonarcloud.io`

## Implementation Details
- The SonarCloud step uses the `sonar-maven-plugin` to analyze code quality metrics
- Analysis runs after JaCoCo coverage reports are generated, ensuring coverage data is included
- GitHub token and SonarCloud token are passed as environment variables for authentication
- Security check prevents running analysis on pull requests from external forks to protect secrets

https://claude.ai/code/session_01VA8hUdDicPugwP5rFwahSb