### PR TITLE
Migrate Coveralls integration to GitHub Actions native action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,16 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package
+    - name: Generate JaCoCo coverage report
+      if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      run: mvn -B jacoco:report
     - name: Publish coverage report to Coveralls
       if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        CI_NAME: github
-        CI_BUILD_NUMBER: ${{ github.run_id }}
-        CI_BUILD_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        CI_BRANCH: ${{ github.head_ref || github.ref_name }}
-        CI_PULL_REQUEST: ${{ github.event.pull_request.number }}
-      run: mvn -B jacoco:report coveralls:report -DrepoToken=$COVERALLS_REPO_TOKEN
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        file: target/site/jacoco/jacoco.xml
+        format: jacoco
     - name: Publish analysis to SonarCloud
       if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       run: mvn -B jacoco:report
     - name: Publish coverage report to Coveralls
       if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-      uses: coverallsapp/github-action@v2
+      uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         file: target/site/jacoco/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -122,18 +122,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.eluder.coveralls</groupId>
-        <artifactId>coveralls-maven-plugin</artifactId>
-        <version>4.3.0</version>
-        <dependencies>
-          <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.15</version>


### PR DESCRIPTION
## Summary
This PR modernizes the Coveralls integration by replacing the Maven-based coveralls plugin with the official `coverallsapp/github-action` GitHub Action. This simplifies the CI/CD pipeline and reduces maintenance overhead.

## Key Changes
- **Workflow updates**: Split the coverage reporting into two separate steps:
  - Added explicit `jacoco:report` step to generate coverage reports
  - Replaced Maven-based `coveralls:report` with the official `coverallsapp/github-action@v2`
- **Removed Maven plugin**: Deleted the `coveralls-maven-plugin` configuration from `pom.xml` along with its JAXB API dependency
- **Simplified authentication**: Replaced custom environment variables with the standard `GITHUB_TOKEN` secret
- **Direct file input**: The action now directly consumes the JaCoCo XML report from `target/site/jacoco/jacoco.xml`

## Implementation Details
- The condition `github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository` is preserved to prevent coverage reporting on external fork PRs
- JaCoCo report generation is now explicitly separated from the Coveralls publication step
- The GitHub Action approach is more maintainable and doesn't require managing Maven plugin versions and dependencies

https://claude.ai/code/session_01QpKfj4VEC49okAe5ay7g1V