### PR TITLE
Pin GitHub Actions to specific commit SHAs and enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default-days: 5
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         fetch-depth: 0
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         java-version: '11'
         distribution: 'temurin'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Set up JDK 11
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with:
         distribution: 'temurin'
         java-version: '11'
@@ -20,7 +20,7 @@ jobs:
       run: mvn -B package
 
     - name: Set up Apache Maven Central
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
       with: # running setup-java again overwrites the settings.xml
         distribution: 'temurin'
         java-version: '11'


### PR DESCRIPTION
## Summary
This PR improves the security and maintainability of GitHub Actions workflows by pinning all action versions to specific commit SHAs and enabling Dependabot to manage GitHub Actions updates.

## Key Changes
- **Pinned GitHub Actions to commit SHAs**: Updated `actions/checkout` and `actions/setup-java` to use full commit hashes instead of major version tags, improving supply chain security
  - `actions/checkout@v3` → `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`
  - `actions/setup-java@v3` → `actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0`
- **Enabled Dependabot for GitHub Actions**: Added a new Dependabot configuration for the `github-actions` package ecosystem with daily update checks and a 5-day cooldown period
- **Added cooldown to npm updates**: Configured a 5-day cooldown period for npm dependency updates to reduce update frequency

## Implementation Details
- All action references now include both the commit SHA and a comment with the semantic version for readability
- Dependabot will automatically create pull requests to update pinned action versions when new releases are available
- The 5-day cooldown on both npm and GitHub Actions updates helps reduce notification fatigue while maintaining regular dependency updates

https://claude.ai/code/session_01HNhqXTb4chnvAQ44nrEd9M