### PR TITLE
Improve GerritAuth token extraction pattern

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/GerritRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/GerritRestClient.java
@@ -86,7 +86,7 @@ import java.util.regex.Pattern;
 public class GerritRestClient implements RestClient {
 
     private static final String JSON_MIME_TYPE = ContentType.APPLICATION_JSON.getMimeType();
-    private static final Pattern GERRIT_AUTH_PATTERN = Pattern.compile(".*?xGerritAuth=\"(.+?)\"");
+    private static final Pattern GERRIT_AUTH_PATTERN = Pattern.compile("xGerritAuth=\"([^\"]+)\"");
     private static final int CONNECTION_TIMEOUT_MS = 300000;
     private static final Gson GSON = GsonFactory.create();
     private static final RequestConfig REQUEST_CONFIG = RequestConfig.custom().setNormalizeUri(false).build();

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/GerritRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/GerritRestClientTest.java
@@ -54,6 +54,8 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static com.urswolfer.gerrit.client.rest.RestClient.HttpVerb.GET;
 import static com.urswolfer.gerrit.client.rest.RestClient.HttpVerb.HEAD;
@@ -354,6 +356,25 @@ public class GerritRestClientTest {
         Truth.assertThat(loginCache.getHostSupportsGerritAuth()).isFalse();
         Truth.assertThat(loginCache.getGerritAuthOptional().isPresent()).isFalse();
         Truth.assertThat(loginCache.isGithubOAuthDetected()).isTrue();
+    }
+
+    /**
+     * Verifies that the GerritAuth-extraction pattern correctly extracts the token value
+     * from the HTML snippet Gerrit embeds in its start page (see login/index.html), and
+     * that it does not match when the attribute is absent.
+     */
+    @Test
+    public void testGerritAuthPatternExtractsToken() throws Exception {
+        Field patternField = GerritRestClient.class.getDeclaredField("GERRIT_AUTH_PATTERN");
+        patternField.setAccessible(true);
+        Pattern gerritAuthPattern = (Pattern) patternField.get(null);
+
+        String html = "gerrit_hostpagedata.xGerritAuth=\"AGaX_CruyH1_pMhQTiv2U-Rr4HXo5VQxe3sAVAnsOrhrcbK7Wxzjdgqr\";";
+        Matcher matcher = gerritAuthPattern.matcher(html);
+        Truth.assertThat(matcher.find()).isTrue();
+        Truth.assertThat(matcher.group(1)).isEqualTo("AGaX_CruyH1_pMhQTiv2U-Rr4HXo5VQxe3sAVAnsOrhrcbK7Wxzjdgqr");
+
+        Truth.assertThat(gerritAuthPattern.matcher("no auth token here").find()).isFalse();
     }
 
     private void requestChanges(GerritRestClient gerritRestClient) throws IOException, HttpStatusException {


### PR DESCRIPTION
## Summary
This PR improves the regex pattern used to extract GerritAuth tokens from Gerrit's HTML and adds comprehensive test coverage to verify the pattern works correctly.

## Key Changes
- **Updated GERRIT_AUTH_PATTERN regex**: Changed from `.*?xGerritAuth=\"(.+?)\"` to `xGerritAuth=\"([^\"]+)\"` for more efficient and precise token extraction
  - Removes unnecessary leading `.*?` wildcard that could cause performance issues with backtracking
  - Uses negated character class `[^\"]+` instead of lazy quantifier `.+?` for clearer intent and better performance
  
- **Added test coverage**: New `testGerritAuthPatternExtractsToken()` test method that:
  - Verifies the pattern correctly extracts the token value from realistic HTML
  - Confirms the pattern does not match when the GerritAuth attribute is absent
  - Uses reflection to access the private static pattern field for testing

## Implementation Details
The regex improvement maintains the same functional behavior while being more efficient. The pattern now explicitly matches the `xGerritAuth="..."` structure without unnecessary wildcards, making it clearer and faster to execute. The test validates both positive and negative cases to ensure robustness.

https://claude.ai/code/session_011ewD72Zud38AEH9fyWHBT3