### PR TITLE
Fix addGroups endpoint path to use BASE_URL constant

### DIFF
--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/groups/GroupApiRestClient.java
@@ -150,7 +150,7 @@ public class GroupApiRestClient extends GroupApi.NotImplemented implements Group
 
     @Override
     public void addGroups(String... groups) throws RestApiException {
-        String restPath = getRequestPath() + "/groups";
+        String restPath = getRequestPath() + BASE_URL;
 
         // Create an object which can be used to create the json for:
         // { groups: [ "group1", "group2 ] }


### PR DESCRIPTION
## Summary
Updated the `addGroups` method in `GroupApiRestClient` to use the `BASE_URL` constant instead of a hardcoded string literal for constructing the REST endpoint path.

## Key Changes
- Changed the REST path construction in `addGroups()` from `getRequestPath() + "/groups"` to `getRequestPath() + BASE_URL`
- This ensures consistency with the codebase's use of constants for endpoint paths

## Implementation Details
This change improves code maintainability by centralizing the endpoint path definition. Using the `BASE_URL` constant instead of a hardcoded string makes the code more consistent with other methods in the class and reduces the risk of path inconsistencies if the endpoint needs to be updated in the future.

https://claude.ai/code/session_013svZhcwX6pbxtVvuUscrbS