### PR TITLE
Bump testng to 7.12.0 and require JDK 11 to build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  JAVA_HOME: C:\Program Files\Java\jdk11
 
 install:
   - set PATH=%JAVA_HOME%\bin;%PATH%

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>7.5</version>
+      <version>7.12.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -120,6 +120,28 @@
           <source>${jdk.min.version}</source>
           <target>${jdk.min.version}</target>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>enforce-build-jdk</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <!-- testng 7.6+ requires JDK 11 to build/run, even though the
+                       compiled artifact still targets Java ${jdk.min.version} -->
+                  <version>[11,)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/src/test/java/com/urswolfer/gerrit/client/rest/RealServerTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/RealServerTest.java
@@ -21,7 +21,6 @@ import com.google.gerrit.extensions.common.AccountInfo;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gson.Gson;
 import com.urswolfer.gerrit.client.rest.http.HttpStatusException;
-import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -43,11 +42,11 @@ public class RealServerTest {
     public Object[][] getData() throws Exception {
         URL url = this.getClass().getResource("testhosts.json");
         if (url == null) {
-            String message =
+            System.out.println(
                 "File 'src/test/resources/com/urswolfer/gerrit/client/rest/testhosts.json' not found.\n" +
                 "Not running any " + getClass().getSimpleName() + " tests.\n" +
-                "Create the json file with following content: '[[\"http://gerrit\", null, null], [\"http://host2\", \"user\", \"pw\"]]'.";
-            throw new SkipException(message);
+                "Create the json file with following content: '[[\"http://gerrit\", null, null], [\"http://host2\", \"user\", \"pw\"]]'.");
+            return new Object[0][];
         }
         File file = new File(url.toURI());
         return new Gson().fromJson(new FileReader(file), Object[][].class);


### PR DESCRIPTION
## Summary
- Bump `testng` from 7.5 to 7.12.0. TestNG raised its own minimum JDK to 11 starting at 7.6.0, so this is the latest version obtainable while the project still targets Java 8 bytecode.
- Add a `maven-enforcer-plugin` check requiring JDK 11+ to build, making explicit the requirement CI (`.github/workflows/build.yml`) already has. The compiled artifact still targets Java 8 (`jdk.min.version`), so this only affects the build/test toolchain, not downstream consumers.
- Fix `RealServerTest`'s `@DataProvider`: throwing `SkipException` from a data provider is reported by TestNG 7.12.0 as a **failure** rather than a skip, which would break the build whenever the opt-in `src/test/resources/.../testhosts.json` fixture is absent (the normal case in CI). Returning an empty data set instead keeps the "no real server configured" case a no-op, as before.

This is one of three independent dependency bumps split out from a broader "bump everything to latest, keep JDK low" pass; see also the Truth and Jetty bump PRs.

## Test plan
- [x] `mvn -B test` passes locally (355 tests, 1 skipped as before, 0 failures)
- [x] `mvn -B validate` confirms the new enforcer rule resolves and runs


---
_Generated by [Claude Code](https://claude.ai/code/session_01YFfqtCahyZNzRKRsQUGATF)_