### PR TITLE
Bump com.google.truth:truth from 0.44 to 1.4.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.44</version>
+      <version>1.4.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
@@ -59,7 +59,7 @@ public class ChangeApiRestClientTest {
 
         List<ReviewerInfo> listReviewers = changeApiRestClient.listReviewers();
 
-        Truth.assertThat(listReviewers).isSameAs(expectedListReviewers);
+        Truth.assertThat(listReviewers).isSameInstanceAs(expectedListReviewers);
         EasyMock.verify(gerritRestClient, reviewerInfoParser);
     }
 
@@ -333,7 +333,7 @@ public class ChangeApiRestClientTest {
 
         List<SuggestedReviewerInfo> suggestedReviewerInfos = changeApiRestClient.suggestReviewers("J").get();
 
-        Truth.assertThat(suggestedReviewerInfos).isSameAs(expectedSuggestedReviewerInfos);
+        Truth.assertThat(suggestedReviewerInfos).isSameInstanceAs(expectedSuggestedReviewerInfos);
         EasyMock.verify(gerritRestClient, reviewerInfosParser);
     }
 
@@ -357,7 +357,7 @@ public class ChangeApiRestClientTest {
 
         List<SuggestedReviewerInfo> suggestedReviewerInfos = changeApiRestClient.suggestReviewers("J").withLimit(5).get();
 
-        Truth.assertThat(suggestedReviewerInfos).isSameAs(expectedSuggestedReviewerInfos);
+        Truth.assertThat(suggestedReviewerInfos).isSameInstanceAs(expectedSuggestedReviewerInfos);
         EasyMock.verify(gerritRestClient, reviewerInfosParser);
     }
 
@@ -379,7 +379,7 @@ public class ChangeApiRestClientTest {
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         ChangeInfo changeInfo = changeApiRestClient.check();
-        Truth.assertThat(changeInfo).isSameAs(expectedChangeInfo);
+        Truth.assertThat(changeInfo).isSameInstanceAs(expectedChangeInfo);
 
         EasyMock.verify(gerritRestClient);
     }
@@ -402,7 +402,7 @@ public class ChangeApiRestClientTest {
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         IncludedInInfo includedInInfo = changeApiRestClient.includedIn();
-        Truth.assertThat(includedInInfo).isSameAs(expectedIncludedInInfo);
+        Truth.assertThat(includedInInfo).isSameInstanceAs(expectedIncludedInInfo);
 
         EasyMock.verify(gerritRestClient);
     }
@@ -432,7 +432,7 @@ public class ChangeApiRestClientTest {
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         ChangeInfo changeInfo = changeApiRestClient.check(fixInput);
-        Truth.assertThat(changeInfo).isSameAs(expectedChangeInfo);
+        Truth.assertThat(changeInfo).isSameInstanceAs(expectedChangeInfo);
 
         EasyMock.verify(gerritRestClient);
     }
@@ -456,7 +456,7 @@ public class ChangeApiRestClientTest {
 
         Map<String, List<CommentInfo>> commentInfos = changeApiRestClient.comments();
 
-        Truth.assertThat(commentInfos).isSameAs(expectedCommentInfos);
+        Truth.assertThat(commentInfos).isSameInstanceAs(expectedCommentInfos);
         EasyMock.verify(gerritRestClient, commentsParser);
     }
 
@@ -479,7 +479,7 @@ public class ChangeApiRestClientTest {
 
         Map<String, List<RobotCommentInfo>> robotCommentInfos = changeApiRestClient.robotComments();
 
-        Truth.assertThat(robotCommentInfos).isSameAs(expectedRobotCommentInfos);
+        Truth.assertThat(robotCommentInfos).isSameInstanceAs(expectedRobotCommentInfos);
         EasyMock.verify(gerritRestClient, commentsParser);
     }
 
@@ -502,7 +502,7 @@ public class ChangeApiRestClientTest {
 
         Map<String, List<CommentInfo>> draftInfos = changeApiRestClient.drafts();
 
-        Truth.assertThat(draftInfos).isSameAs(expectedDraftInfos);
+        Truth.assertThat(draftInfos).isSameInstanceAs(expectedDraftInfos);
         EasyMock.verify(gerritRestClient, commentsParser);
     }
 
@@ -525,7 +525,7 @@ public class ChangeApiRestClientTest {
 
         List<ChangeMessageInfo> messageInfos = changeApiRestClient.messages();
 
-        Truth.assertThat(messageInfos).isSameAs(expectedMessageInfos);
+        Truth.assertThat(messageInfos).isSameInstanceAs(expectedMessageInfos);
         EasyMock.verify(gerritRestClient, commentsParser);
     }
 
@@ -548,7 +548,7 @@ public class ChangeApiRestClientTest {
 
         Set<String> hashtags = changeApiRestClient.getHashtags();
 
-        Truth.assertThat(hashtags).isSameAs(expectedHashtags);
+        Truth.assertThat(hashtags).isSameInstanceAs(expectedHashtags);
         EasyMock.verify(gerritRestClient, changeInfosParser);
     }
 
@@ -570,7 +570,7 @@ public class ChangeApiRestClientTest {
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         EditInfo editInfo = changeApiRestClient.getEdit();
-        Truth.assertThat(editInfo).isSameAs(expectedEditInfo);
+        Truth.assertThat(editInfo).isSameInstanceAs(expectedEditInfo);
 
         EasyMock.verify(gerritRestClient);
     }
@@ -623,7 +623,7 @@ public class ChangeApiRestClientTest {
         assigneeInput.assignee = "foo";
         AccountInfo assigneeInfo =
             changeApiRestClient.setAssignee(assigneeInput);
-        Truth.assertThat(assigneeInfo).isSameAs(info);
+        Truth.assertThat(assigneeInfo).isSameInstanceAs(info);
         EasyMock.verify(gerritRestClient, accountsParser);
     }
 
@@ -646,7 +646,7 @@ public class ChangeApiRestClientTest {
 
         AccountInfo assigneeInfo = changeApiRestClient.getAssignee();
 
-        Truth.assertThat(assigneeInfo).isSameAs(expectedAssignee);
+        Truth.assertThat(assigneeInfo).isSameInstanceAs(expectedAssignee);
         EasyMock.verify(gerritRestClient, accountsParser);
     }
 
@@ -669,7 +669,7 @@ public class ChangeApiRestClientTest {
 
         List<AccountInfo> pastAssigneesInfo = changeApiRestClient.getPastAssignees();
 
-        Truth.assertThat(pastAssigneesInfo).isSameAs(expectedPastAssignees);
+        Truth.assertThat(pastAssigneesInfo).isSameInstanceAs(expectedPastAssignees);
         EasyMock.verify(gerritRestClient, accountsParser);
     }
 
@@ -692,7 +692,7 @@ public class ChangeApiRestClientTest {
         assigneeInput.assignee = "foo";
         AccountInfo assigneeInfo =
             changeApiRestClient.deleteAssignee();
-        Truth.assertThat(assigneeInfo).isSameAs(info);
+        Truth.assertThat(assigneeInfo).isSameInstanceAs(info);
         EasyMock.verify(gerritRestClient, accountsParser);
     }
 
@@ -714,7 +714,7 @@ public class ChangeApiRestClientTest {
         EnumSet<ListChangesOption> options = EnumSet.of(ListChangesOption.LABELS, ListChangesOption.DETAILED_LABELS);
         ChangeInfo result = changeApiRestClient.get(options);
 
-        Truth.assertThat(result).isSameAs(expectedChangeInfo);
+        Truth.assertThat(result).isSameInstanceAs(expectedChangeInfo);
         EasyMock.verify(gerritRestClient, changeInfosParser);
     }
 
@@ -756,7 +756,7 @@ public class ChangeApiRestClientTest {
             null, null, null, null, expectedChangeId);
         ChangeInfo result = changeApiRestClient.get();
 
-        Truth.assertThat(result).isSameAs(expectedChangeInfo);
+        Truth.assertThat(result).isSameInstanceAs(expectedChangeInfo);
         EasyMock.verify(gerritRestClient, changeInfosParser);
     }
 
@@ -787,7 +787,7 @@ public class ChangeApiRestClientTest {
             null, null, null, null, expectedChangeId);
         ChangeInfo result = changeApiRestClient.get();
 
-        Truth.assertThat(result).isSameAs(expectedChangeInfo);
+        Truth.assertThat(result).isSameInstanceAs(expectedChangeInfo);
         EasyMock.verify(gerritRestClient, changeInfosParser);
     }
 
@@ -808,7 +808,7 @@ public class ChangeApiRestClientTest {
             "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
         ChangeInfo result = changeApiRestClient.info();
 
-        Truth.assertThat(result).isSameAs(expectedChangeInfo);
+        Truth.assertThat(result).isSameInstanceAs(expectedChangeInfo);
         EasyMock.verify(gerritRestClient, changeInfosParser);
     }
 
@@ -843,7 +843,7 @@ public class ChangeApiRestClientTest {
 "myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
 
         List<ChangeInfo> changeInfos = changeApiRestClient.submittedTogether();
-        Truth.assertThat(changeInfos).isSameAs(expectedChangeInfos);
+        Truth.assertThat(changeInfos).isSameInstanceAs(expectedChangeInfos);
 
         EasyMock.verify(gerritRestClient);
     }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/DraftsApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/DraftsApiRestClientTest.java
@@ -76,7 +76,7 @@ public class DraftsApiRestClientTest extends AbstractParserTest {
 
         CommentInfo commentInfo = draftApiRestClient.get();
 
-        Truth.assertThat(commentInfo).isSameAs(expectedCommentInfo);
+        Truth.assertThat(commentInfo).isSameInstanceAs(expectedCommentInfo);
         EasyMock.verify(gerritRestClient);
     }
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ReviewerApiRestClientTest.java
@@ -47,7 +47,7 @@ public class ReviewerApiRestClientTest extends AbstractParserTest {
         ReviewerApiRestClient reviewerApiRestClient = new ReviewerApiRestClient(gerritRestClient, changeApiRestClient, ACCOUNT_ID);
         Map<String, Short> votes = reviewerApiRestClient.votes();
 
-        Truth.assertThat(votes.get("Work-In-Progress")).isSameAs((short) 2);
+        Truth.assertThat(votes.get("Work-In-Progress")).isSameInstanceAs((short) 2);
         EasyMock.verify(gerritRestClient);
     }
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/parsers/ChangeInfosParserTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/parsers/ChangeInfosParserTest.java
@@ -166,7 +166,7 @@ public class ChangeInfosParserTest extends AbstractParserTest {
         IncludedInInfo includedInInfo = changeInfosParser.parseIncludedInInfos(jsonElement);
         Truth.assertThat(includedInInfo.branches).hasSize(4);
         Truth.assertThat(includedInInfo.tags).hasSize(3);
-        Truth.assertThat(includedInInfo.branches).containsAllOf("integration/master", "integration/releases/2.12", "master", "releases/2.12");
-        Truth.assertThat(includedInInfo.tags).containsAllOf("2017-12_v2.12", "2017-12_v2.13", "v2.13.1_xyz");
+        Truth.assertThat(includedInInfo.branches).containsAtLeast("integration/master", "integration/releases/2.12", "master", "releases/2.12");
+        Truth.assertThat(includedInInfo.tags).containsAtLeast("2017-12_v2.12", "2017-12_v2.13", "v2.13.1_xyz");
     }
 }


### PR DESCRIPTION
## Summary
- Bump `com.google.truth:truth` from 0.44 (2016-era) to the latest 1.4.5. Truth 1.4.5 still targets Java 8, so no JDK bump is needed for this one.
- Migrate the two APIs that were renamed/removed since 0.44:
  - `Subject.isSameAs(Object)` → `Subject.isSameInstanceAs(Object)`. These call sites assert that an EasyMock-mocked parser returns the exact stubbed instance, i.e. they're genuinely reference-equality checks, which is what the renamed method preserves (the old `isSameAs` name became ambiguous with equals-based assertions and was split into `isEqualTo`/`isSameInstanceAs` upstream).
  - `IterableSubject.containsAllOf(...)` → `IterableSubject.containsAtLeast(...)`.

This is one of three independent dependency bumps split out from a broader "bump everything to latest, keep JDK low" pass; see also the JDK 11/testng bump and Jetty bump PRs.

## Test plan
- [x] `mvn -B test` passes locally (355 tests, 1 skipped as before, 0 failures)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YFfqtCahyZNzRKRsQUGATF)_