### PR TITLE
Bump embedded test Jetty from 8.2.0.v20160908 to 9.4.57.v20241219

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.min.version>8</jdk.min.version>
-    <jetty.version>8.2.0.v20160908</jetty.version>
+    <jetty.version>9.4.57.v20241219</jetty.version>
     <sonar.organization>uwolfer-github</sonar.organization>
     <sonar.projectKey>com.urswolfer.gerrit.client.rest:gerrit-rest-java-client</sonar.projectKey>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/GerritRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/GerritRestClientTest.java
@@ -33,10 +33,12 @@ import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.HashLoginService;
 import org.eclipse.jetty.security.SecurityHandler;
+import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -84,8 +86,19 @@ public class GerritRestClientTest {
         resourceHandler.setBaseResource(new FileResource(url));
         resourceHandler.setWelcomeFiles(new String[] {"changes.json", "projects.json", "account.json"});
 
+        // wrap in a context so welcome-file resolution for a directory path requested
+        // without a trailing slash (e.g. "/accounts/self") isn't rejected as an alias;
+        // safe here since this only ever serves this test's own static fixture files
+        ContextHandler resourceContextHandler = new ContextHandler("/");
+        resourceContextHandler.addAliasCheck(new ContextHandler.ApproveAliases());
+        resourceContextHandler.setHandler(resourceHandler);
+
         ServletContextHandler servletContextHandler = new ServletContextHandler();
         servletContextHandler.addServlet(loginServletClass, "/login/");
+        // let requests for paths other than the login servlet fall through to the
+        // resourceHandler/basicAuthContextHandler siblings instead of being answered
+        // with a 404 by Jetty's own auto-registered default servlet
+        servletContextHandler.getServletHandler().setEnsureDefaultServlet(false);
 
         ServletContextHandler basicAuthContextHandler = new ServletContextHandler(ServletContextHandler.SECURITY);
         basicAuthContextHandler.setSecurityHandler(basicAuth("foo", "bar", "Gerrit Auth"));
@@ -94,22 +107,25 @@ public class GerritRestClientTest {
         HandlerCollection handlers = new HandlerCollection();
         handlers.setHandlers(new Handler[] {
             servletContextHandler,
-            resourceHandler,
+            resourceContextHandler,
             basicAuthContextHandler
         });
         server.setHandler(handlers);
 
         server.start();
 
-        Connector connector = server.getConnectors()[0];
+        NetworkConnector connector = (NetworkConnector) server.getConnectors()[0];
         String host = "localhost";
         int port = connector.getLocalPort();
         return String.format("http://%s:%s", host, port);
     }
 
     private static SecurityHandler basicAuth(String username, String password, String realm) {
+        UserStore userStore = new UserStore();
+        userStore.addUser(username, Credential.getCredential(password), new String[]{"user"});
+
         HashLoginService loginService = new HashLoginService();
-        loginService.putUser(username, Credential.getCredential(password), new String[]{"user"});
+        loginService.setUserStore(userStore);
         loginService.setName(realm);
 
         Constraint constraint = new Constraint();


### PR DESCRIPTION
## Summary
- Bump the test-scope `jetty-server`/`jetty-servlet` dependency from the 2016-era `8.2.0.v20160908` to `9.4.57.v20241219` - the latest release on the still Java-8-compatible 9.4.x line. (Jetty 10/11 require Java 11, Jetty 12 requires Java 17; staying on 9.4.x means this bump needs no JDK change, unlike jumping to Jetty's actively-developed 12.x line.)
- Update `GerritRestClientTest`'s embedded server setup for Jetty 9's API and behavior changes:
  - `HashLoginService.putUser(...)` was removed; credentials are now registered via a `UserStore` passed to `setUserStore(...)`.
  - `Connector` no longer exposes `getLocalPort()`; cast to `NetworkConnector`.
  - `ServletContextHandler` now auto-registers a default 404 servlet for any unmapped path in its context ("ensure default servlet"). Since the login servlet's context defaults to `"/"`, this made it swallow every request before it could fall through to the sibling resource/security handlers. Disabled via `setEnsureDefaultServlet(false)` to restore the original handler-chain fallthrough.
  - A standalone `ResourceHandler` (no enclosing context) now rejects requests where the resolved resource's canonical path differs from the requested one, treating it as a security-sensitive "alias" - which is exactly what happens for a directory requested without its trailing slash (e.g. `/accounts/self`, used here for welcome-file resolution). Wrapped it in a `ContextHandler` with `ApproveAliases` to restore the previous behavior; safe here since it only ever serves this test's own static fixture files under `src/test/resources`.

This is one of three independent dependency bumps split out from a broader "bump everything to latest, keep JDK low" pass; see also the JDK 11/testng bump and Truth bump PRs.

## Test plan
- [x] `mvn -B test` passes locally (355 tests, 1 skipped as before, 0 failures)
- [x] Verified the alias-rejection and default-servlet behavior changes against the actual Jetty 9.4.57 jars with standalone repro servers before settling on the fix


---
_Generated by [Claude Code](https://claude.ai/code/session_01YFfqtCahyZNzRKRsQUGATF)_