### PR TITLE
Require JDK 11 to build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,16 @@
-environment:
-  JAVA_HOME: C:\Program Files\Java\jdk11
-
 install:
-  - set PATH=%JAVA_HOME%\bin;%PATH%
+  - ps: |
+      $jdk = Get-ChildItem 'C:\Program Files\Java' -Directory |
+        Where-Object { $_.Name -match '^jdk-?(\d+)' -and [int]$Matches[1] -ge 11 } |
+        Sort-Object { [int]([regex]::Match($_.Name, '\d+').Value) } |
+        Select-Object -First 1
+      if (-not $jdk) {
+          throw "No JDK 11+ found under 'C:\Program Files\Java'"
+      }
+      Write-Host "Using $($jdk.FullName) as JAVA_HOME"
+      $env:JAVA_HOME = $jdk.FullName
+      $env:PATH = "$($jdk.FullName)\bin;$env:PATH"
+  - java -version
 
 cache:
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  JAVA_HOME: C:\Program Files\Java\jdk11
 
 install:
   - set PATH=%JAVA_HOME%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,8 @@
 install:
-  - ps: |
-      $jdk = Get-ChildItem 'C:\Program Files\Java' -Directory |
-        Where-Object { $_.Name -match '^jdk-?(\d+)' -and [int]$Matches[1] -ge 11 } |
-        Sort-Object { [int]([regex]::Match($_.Name, '\d+').Value) } |
-        Select-Object -First 1
-      if (-not $jdk) {
-          throw "No JDK 11+ found under 'C:\Program Files\Java'"
-      }
-      Write-Host "Using $($jdk.FullName) as JAVA_HOME"
-      $env:JAVA_HOME = $jdk.FullName
-      $env:PATH = "$($jdk.FullName)\bin;$env:PATH"
+  - choco install temurin11 --no-progress -y
+  - cmd: |
+      FOR /D %%F IN ("C:\Program Files\Eclipse Adoptium\jdk-11*") DO SET JAVA_HOME=%%F
+      SET PATH=%JAVA_HOME%\bin;%PATH%
   - java -version
 
 cache:

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,29 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>enforce-build-jdk</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <!-- CI already builds with JDK 11; make that requirement explicit
+                       and fail fast on older JDKs, while the compiled artifact still
+                       targets Java ${jdk.min.version} so downstream consumers see no change -->
+                  <version>[11,)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.15</version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>enforce-build-jdk</id>


### PR DESCRIPTION
## Summary
- Add a `maven-enforcer-plugin` check requiring JDK 11+ to build, making explicit the requirement CI (`.github/workflows/build.yml`) already has. The compiled artifact still targets Java 8 (`jdk.min.version`), so this only affects the build/test toolchain, not downstream consumers.
- Bump AppVeyor's `JAVA_HOME` from JDK 8 to JDK 11 to match, since it was still pinned to JDK 8 and would otherwise fail once anything in the build needs JDK 11.

This paves the way for a follow-up bumping `testng` to its latest release (7.6+ itself requires JDK 11), split out as a separate PR per feedback on the original combined PR (#290, closing in favor of this split).

## Test plan
- [x] `mvn -B test` passes locally
- [x] `mvn -B validate` confirms the new enforcer rule resolves and runs


---
_Generated by [Claude Code](https://claude.ai/code/session_01YFfqtCahyZNzRKRsQUGATF)_