### PR TITLE
Bump testng from 7.5 to 7.12.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,16 @@
-environment:
-  JAVA_HOME: C:\Program Files\Java\jdk11
-
 install:
-  - set PATH=%JAVA_HOME%\bin;%PATH%
+  - ps: |
+      $jdk = Get-ChildItem 'C:\Program Files\Java' -Directory |
+        Where-Object { $_.Name -match '^jdk-?(\d+)' -and [int]$Matches[1] -ge 11 } |
+        Sort-Object { [int]([regex]::Match($_.Name, '\d+').Value) } |
+        Select-Object -First 1
+      if (-not $jdk) {
+          throw "No JDK 11+ found under 'C:\Program Files\Java'"
+      }
+      Write-Host "Using $($jdk.FullName) as JAVA_HOME"
+      $env:JAVA_HOME = $jdk.FullName
+      $env:PATH = "$($jdk.FullName)\bin;$env:PATH"
+  - java -version
 
 cache:
   - C:\Users\appveyor\.m2\ -> pom.xml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 environment:
-  JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  JAVA_HOME: C:\Program Files\Java\jdk11
 
 install:
   - set PATH=%JAVA_HOME%\bin;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,8 @@
 install:
-  - ps: |
-      $jdk = Get-ChildItem 'C:\Program Files\Java' -Directory |
-        Where-Object { $_.Name -match '^jdk-?(\d+)' -and [int]$Matches[1] -ge 11 } |
-        Sort-Object { [int]([regex]::Match($_.Name, '\d+').Value) } |
-        Select-Object -First 1
-      if (-not $jdk) {
-          throw "No JDK 11+ found under 'C:\Program Files\Java'"
-      }
-      Write-Host "Using $($jdk.FullName) as JAVA_HOME"
-      $env:JAVA_HOME = $jdk.FullName
-      $env:PATH = "$($jdk.FullName)\bin;$env:PATH"
+  - choco install temurin11 --no-progress -y
+  - cmd: |
+      FOR /D %%F IN ("C:\Program Files\Eclipse Adoptium\jdk-11*") DO SET JAVA_HOME=%%F
+      SET PATH=%JAVA_HOME%\bin;%PATH%
   - java -version
 
 cache:

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,29 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>3.5.0</version>
+        <executions>
+          <execution>
+            <id>enforce-build-jdk</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <!-- CI already builds with JDK 11; make that requirement explicit
+                       and fail fast on older JDKs, while the compiled artifact still
+                       targets Java ${jdk.min.version} so downstream consumers see no change -->
+                  <version>[11,)</version>
+                </requireJavaVersion>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>0.8.15</version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
-      <version>7.5</version>
+      <version>7.12.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.5.0</version>
+        <version>3.0.0</version>
         <executions>
           <execution>
             <id>enforce-build-jdk</id>

--- a/src/test/java/com/urswolfer/gerrit/client/rest/RealServerTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/RealServerTest.java
@@ -21,7 +21,6 @@ import com.google.gerrit.extensions.common.AccountInfo;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gson.Gson;
 import com.urswolfer.gerrit.client.rest.http.HttpStatusException;
-import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -43,11 +42,11 @@ public class RealServerTest {
     public Object[][] getData() throws Exception {
         URL url = this.getClass().getResource("testhosts.json");
         if (url == null) {
-            String message =
+            System.out.println(
                 "File 'src/test/resources/com/urswolfer/gerrit/client/rest/testhosts.json' not found.\n" +
                 "Not running any " + getClass().getSimpleName() + " tests.\n" +
-                "Create the json file with following content: '[[\"http://gerrit\", null, null], [\"http://host2\", \"user\", \"pw\"]]'.";
-            throw new SkipException(message);
+                "Create the json file with following content: '[[\"http://gerrit\", null, null], [\"http://host2\", \"user\", \"pw\"]]'.");
+            return new Object[0][];
         }
         File file = new File(url.toURI());
         return new Gson().fromJson(new FileReader(file), Object[][].class);


### PR DESCRIPTION
## Summary
Follow-up to #293 (require JDK 11 to build). Now that the build requires JDK 11, testng can be bumped to its latest release:

- Bump `testng` from 7.5 to 7.12.0 (TestNG 7.6+ raised its own minimum JDK to 11, so 7.12.0 is the latest version obtainable now that the build targets JDK 11).
- Fix `RealServerTest`'s `@DataProvider`: throwing `SkipException` from a data provider is reported by TestNG 7.12.0 as a **failure** rather than a skip, which would break the build whenever the opt-in `src/test/resources/.../testhosts.json` fixture is absent (the normal case in CI). Returning an empty data set instead keeps the "no real server configured" case a no-op, as before.

This PR is based on #293's branch - it'll show as just this diff once #293 merges and GitHub retargets it to master.

## Test plan
- [x] `mvn -B test` passes locally (355 tests, 1 skipped as before, 0 failures)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YFfqtCahyZNzRKRsQUGATF)_