### PR TITLE
Skip coverage reports for dependabot pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,17 +28,17 @@ jobs:
     - name: Build with Maven
       run: mvn -B package
     - name: Generate JaCoCo coverage report
-      if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
       run: mvn -B jacoco:report
     - name: Publish coverage report to Coveralls
-      if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         file: target/site/jacoco/jacoco.xml
         format: jacoco
     - name: Publish analysis to SonarCloud
-      if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+      if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,17 +28,17 @@ jobs:
     - name: Build with Maven
       run: mvn -B package
     - name: Generate JaCoCo coverage report
-      if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+      if: github.event.pull_request.user.login != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
       run: mvn -B jacoco:report
     - name: Publish coverage report to Coveralls
-      if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+      if: github.event.pull_request.user.login != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
       uses: coverallsapp/github-action@8d6379e14d29928660c4ba802d8e85393440b329 # v2.3.8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         file: target/site/jacoco/jacoco.xml
         format: jacoco
     - name: Publish analysis to SonarCloud
-      if: github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+      if: github.event.pull_request.user.login != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow to skip code coverage and analysis steps when pull requests are created by dependabot, preventing unnecessary processing of dependency update PRs.

## Key Changes
- Added `github.actor != 'dependabot[bot]'` condition to three workflow steps:
  - Generate JaCoCo coverage report
  - Publish coverage report to Coveralls
  - Publish analysis to SonarCloud
- These steps now only run for push events, internal pull requests, or pull requests from non-dependabot actors

## Implementation Details
The condition `github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)` ensures that:
- Dependabot PRs skip expensive coverage and analysis operations
- Regular push events and internal PRs continue to generate and publish coverage reports as before
- This reduces unnecessary CI/CD overhead while maintaining code quality checks for human-authored changes

https://claude.ai/code/session_011ipza9d9N9ST7xfmccocnx