### PR TITLE
Bump vendored com.google.gerrit.extensions copies to latest upstream

### DIFF
--- a/src/main/java/com/google/gerrit/common/ConvertibleToProto.java
+++ b/src/main/java/com/google/gerrit/common/ConvertibleToProto.java
@@ -1,0 +1,26 @@
+// Copyright (C) 2021 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.common;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/** An annotation used to mark Java entities that have equivalent proto representations. */
+@Retention(RUNTIME)
+@Target({TYPE})
+public @interface ConvertibleToProto {}

--- a/src/main/java/com/google/gerrit/common/UsedAt.java
+++ b/src/main/java/com/google/gerrit/common/UsedAt.java
@@ -1,0 +1,61 @@
+// Copyright (C) 2018 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.common;
+
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * A marker to say a method/type/field/constructor is added or is increased to public solely because
+ * it is called from inside a project or an organisation using Gerrit.
+ */
+@Target({METHOD, TYPE, FIELD, CONSTRUCTOR})
+@Retention(RUNTIME)
+@Repeatable(UsedAt.Uses.class)
+public @interface UsedAt {
+  enum Project {
+    COLLABNET,
+    GOOGLE,
+    PLUGINS_ALL,
+    PLUGIN_CHECKS,
+    PLUGIN_CODE_OWNERS,
+    PLUGIN_DELETE_PROJECT,
+    PLUGIN_GITHUB,
+    PLUGIN_HIGH_AVAILABILITY,
+    PLUGIN_MULTI_SITE,
+    PLUGIN_PULL_REPLICATION,
+    PLUGIN_REVIEWERS,
+    PLUGIN_SERVICEUSER,
+    PLUGIN_WEBSESSION_FLATFILE,
+    MODULE_GIT_REFS_FILTER,
+    MODULE_VIRTUALHOST
+  }
+
+  Project value();
+
+  @Retention(RUNTIME)
+  @Target(ElementType.TYPE)
+  @interface Uses {
+    UsedAt[] value();
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/annotations/ExtensionPoint.java
+++ b/src/main/java/com/google/gerrit/extensions/annotations/ExtensionPoint.java
@@ -1,0 +1,34 @@
+// Copyright (C) 2012 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.annotations;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for interfaces that accept auto-registered implementations.
+ *
+ * <p>Interfaces that accept automatically registered implementations into their DynamicSet must be
+ * tagged with this annotation.
+ *
+ * <p>Plugins or extensions that implement an {@code @ExtensionPoint} interface should use the
+ * {@code Listen} annotation to automatically register.
+ */
+@Target({ElementType.TYPE})
+@Retention(RUNTIME)
+public @interface ExtensionPoint {}

--- a/src/main/java/com/google/gerrit/extensions/api/access/ProjectAccessInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/api/access/ProjectAccessInfo.java
@@ -31,6 +31,7 @@ public class ProjectAccessInfo {
   public Boolean canAdd;
   public Boolean canAddTags;
   public Boolean configVisible;
+  public Boolean requireChangeForConfigUpdate;
   public Map<String, GroupInfo> groups;
   public List<WebLinkInfo> configWebLinks;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/accounts/AccountApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/accounts/AccountApi.java
@@ -14,7 +14,10 @@
 
 package com.google.gerrit.extensions.api.accounts;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.extensions.api.changes.StarsInput;
+import com.google.gerrit.extensions.auth.AuthTokenInfo;
+import com.google.gerrit.extensions.auth.AuthTokenInput;
 import com.google.gerrit.extensions.client.DiffPreferencesInfo;
 import com.google.gerrit.extensions.client.EditPreferencesInfo;
 import com.google.gerrit.extensions.client.GeneralPreferencesInfo;
@@ -22,6 +25,7 @@ import com.google.gerrit.extensions.client.ProjectWatchInfo;
 import com.google.gerrit.extensions.common.AccountDetailInfo;
 import com.google.gerrit.extensions.common.AccountExternalIdInfo;
 import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.AccountStateInfo;
 import com.google.gerrit.extensions.common.AgreementInfo;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.EmailInfo;
@@ -39,6 +43,8 @@ public interface AccountApi {
 
   AccountDetailInfo detail() throws RestApiException;
 
+  AccountStateInfo state() throws RestApiException;
+
   boolean getActive() throws RestApiException;
 
   void setActive(boolean active) throws RestApiException;
@@ -47,18 +53,22 @@ public interface AccountApi {
 
   GeneralPreferencesInfo getPreferences() throws RestApiException;
 
+  @CanIgnoreReturnValue
   GeneralPreferencesInfo setPreferences(GeneralPreferencesInfo in) throws RestApiException;
 
   DiffPreferencesInfo getDiffPreferences() throws RestApiException;
 
+  @CanIgnoreReturnValue
   DiffPreferencesInfo setDiffPreferences(DiffPreferencesInfo in) throws RestApiException;
 
   EditPreferencesInfo getEditPreferences() throws RestApiException;
 
+  @CanIgnoreReturnValue
   EditPreferencesInfo setEditPreferences(EditPreferencesInfo in) throws RestApiException;
 
   List<ProjectWatchInfo> getWatchedProjects() throws RestApiException;
 
+  @CanIgnoreReturnValue
   List<ProjectWatchInfo> setWatchedProjects(List<ProjectWatchInfo> in) throws RestApiException;
 
   void deleteWatchedProjects(List<ProjectWatchInfo> in) throws RestApiException;
@@ -66,12 +76,6 @@ public interface AccountApi {
   void starChange(String changeId) throws RestApiException;
 
   void unstarChange(String changeId) throws RestApiException;
-
-  void setStars(String changeId, StarsInput input) throws RestApiException;
-
-  SortedSet<String> getStars(String changeId) throws RestApiException;
-
-  List<ChangeInfo> getStarredChanges() throws RestApiException;
 
   List<GroupInfo> getGroups() throws RestApiException;
 
@@ -81,6 +85,7 @@ public interface AccountApi {
 
   void deleteEmail(String email) throws RestApiException;
 
+  @CanIgnoreReturnValue
   EmailApi createEmail(EmailInput emailInput) throws RestApiException;
 
   EmailApi email(String email) throws RestApiException;
@@ -91,12 +96,14 @@ public interface AccountApi {
 
   List<SshKeyInfo> listSshKeys() throws RestApiException;
 
+  @CanIgnoreReturnValue
   SshKeyInfo addSshKey(String key) throws RestApiException;
 
   void deleteSshKey(int seq) throws RestApiException;
 
   Map<String, GpgKeyInfo> listGpgKeys() throws RestApiException;
 
+  @CanIgnoreReturnValue
   Map<String, GpgKeyInfo> putGpgKeys(List<String> add, List<String> remove) throws RestApiException;
 
   GpgKeyApi gpgKey(String id) throws RestApiException;
@@ -111,16 +118,23 @@ public interface AccountApi {
 
   void deleteExternalIds(List<String> externalIds) throws RestApiException;
 
+  @CanIgnoreReturnValue
   List<DeletedDraftCommentInfo> deleteDraftComments(DeleteDraftCommentsInput input)
       throws RestApiException;
 
   void setName(String name) throws RestApiException;
+
+  @CanIgnoreReturnValue
+  AuthTokenInfo createToken(AuthTokenInput input) throws RestApiException;
+
+  List<AuthTokenInfo> getTokens() throws RestApiException;
 
   /**
    * Generate a new HTTP password.
    *
    * @return the generated password.
    */
+  @Deprecated
   String generateHttpPassword() throws RestApiException;
 
   /**
@@ -131,7 +145,27 @@ public interface AccountApi {
    * @param httpPassword the new password, {@code null} to remove the password.
    * @return the new password, {@code null} if the password was removed.
    */
+  @CanIgnoreReturnValue
+  @Deprecated
   String setHttpPassword(String httpPassword) throws RestApiException;
+
+  void delete() throws RestApiException;
+
+  // The "star" feature (as distinct from starChange/unstarChange above) was removed from this
+  // interface upstream. The methods below are kept, deprecated, for source/binary compatibility
+  // with existing implementers/callers of this interface.
+
+  /** @deprecated removed upstream; the underlying REST resource may still exist. */
+  @Deprecated
+  void setStars(String changeId, StarsInput input) throws RestApiException;
+
+  /** @deprecated removed upstream; the underlying REST resource may still exist. */
+  @Deprecated
+  SortedSet<String> getStars(String changeId) throws RestApiException;
+
+  /** @deprecated removed upstream; the underlying REST resource may still exist. */
+  @Deprecated
+  List<ChangeInfo> getStarredChanges() throws RestApiException;
 
   /**
    * A default implementation which allows source compatibility when adding new methods to the
@@ -145,6 +179,11 @@ public interface AccountApi {
 
     @Override
     public AccountDetailInfo detail() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public AccountStateInfo state() throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -169,8 +208,7 @@ public interface AccountApi {
     }
 
     @Override
-    public GeneralPreferencesInfo setPreferences(GeneralPreferencesInfo in)
-        throws RestApiException {
+    public GeneralPreferencesInfo setPreferences(GeneralPreferencesInfo in) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -200,8 +238,7 @@ public interface AccountApi {
     }
 
     @Override
-    public List<ProjectWatchInfo> setWatchedProjects(List<ProjectWatchInfo> in)
-        throws RestApiException {
+    public List<ProjectWatchInfo> setWatchedProjects(List<ProjectWatchInfo> in) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -217,21 +254,6 @@ public interface AccountApi {
 
     @Override
     public void unstarChange(String changeId) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public void setStars(String changeId, StarsInput input) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public SortedSet<String> getStars(String changeId) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public List<ChangeInfo> getStarredChanges() throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -256,7 +278,7 @@ public interface AccountApi {
     }
 
     @Override
-    public EmailApi createEmail(EmailInput input) throws RestApiException {
+    public EmailApi createEmail(EmailInput emailInput) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -291,18 +313,17 @@ public interface AccountApi {
     }
 
     @Override
-    public Map<String, GpgKeyInfo> putGpgKeys(List<String> add, List<String> remove)
-        throws RestApiException {
+    public Map<String, GpgKeyInfo> listGpgKeys() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map<String, GpgKeyInfo> putGpgKeys(List<String> add, List<String> remove) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
     public GpgKeyApi gpgKey(String id) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public Map<String, GpgKeyInfo> listGpgKeys() throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -332,13 +353,22 @@ public interface AccountApi {
     }
 
     @Override
-    public List<DeletedDraftCommentInfo> deleteDraftComments(DeleteDraftCommentsInput input)
-        throws RestApiException {
+    public List<DeletedDraftCommentInfo> deleteDraftComments(DeleteDraftCommentsInput input) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
     public void setName(String name) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public AuthTokenInfo createToken(AuthTokenInput input) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public List<AuthTokenInfo> getTokens() throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -349,6 +379,26 @@ public interface AccountApi {
 
     @Override
     public String setHttpPassword(String httpPassword) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void delete() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void setStars(String changeId, StarsInput input) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public SortedSet<String> getStars(String changeId) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public List<ChangeInfo> getStarredChanges() throws RestApiException {
       throw new NotImplementedException();
     }
   }

--- a/src/main/java/com/google/gerrit/extensions/api/accounts/AccountInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/accounts/AccountInput.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.extensions.api.accounts;
 
+import com.google.gerrit.extensions.auth.AuthTokenInput;
 import com.google.gerrit.extensions.restapi.DefaultInput;
 import java.util.List;
 
@@ -23,6 +24,7 @@ public class AccountInput {
   public String displayName;
   public String email;
   public String sshKey;
-  public String httpPassword;
+  @Deprecated public String httpPassword;
+  public List<AuthTokenInput> tokens;
   public List<String> groups;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/accounts/Accounts.java
+++ b/src/main/java/com/google/gerrit/extensions/api/accounts/Accounts.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.extensions.api.accounts;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.extensions.client.ListAccountsOption;
 import com.google.gerrit.extensions.common.AccountInfo;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
@@ -38,7 +39,11 @@ public interface Accounts {
    */
   AccountApi id(String id) throws RestApiException;
 
-  /** @see #id(String) */
+  /**
+   * Look up an account by ID. #id(String)
+   *
+   * <p>See #id(String)
+   */
   AccountApi id(int id) throws RestApiException;
 
   /**
@@ -49,9 +54,11 @@ public interface Accounts {
   AccountApi self() throws RestApiException;
 
   /** Create a new account with the given username and default options. */
+  @CanIgnoreReturnValue
   AccountApi create(String username) throws RestApiException;
 
   /** Create a new account. */
+  @CanIgnoreReturnValue
   AccountApi create(AccountInput input) throws RestApiException;
 
   /**

--- a/src/main/java/com/google/gerrit/extensions/api/accounts/EmailInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/accounts/EmailInput.java
@@ -18,16 +18,20 @@ import com.google.gerrit.extensions.restapi.DefaultInput;
 
 /** This entity contains information for registering a new email address. */
 public class EmailInput {
-  /* The email address. If provided, must match the email address from the URL. */
+  /** The email address. If provided, must match the email address from the URL. */
   @DefaultInput public String email;
 
-  /* Whether the new email address should become the preferred email address of
-   * the user. Only supported if {@link #noConfirmation} is set or if the
-   * authentication type is DEVELOPMENT_BECOME_ANY_ACCOUNT.*/
+  /**
+   * Whether the new email address should become the preferred email address of the user. Only
+   * supported if {@link #noConfirmation} is set or if the authentication type is
+   * DEVELOPMENT_BECOME_ANY_ACCOUNT.
+   */
   public boolean preferred;
 
-  /* Whether the email address should be added without confirmation. In this
-   * case no verification email is sent to the user. Only Gerrit administrators
-   * are allowed to add email addresses without confirmation. */
+  /**
+   * Whether the email address should be added without confirmation. In this case no verification
+   * email is sent to the user. Only Gerrit administrators are allowed to add email addresses
+   * without confirmation.
+   */
   public boolean noConfirmation;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ActionVisitor.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ActionVisitor.java
@@ -1,0 +1,62 @@
+// Copyright (C) 2016 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+import com.google.gerrit.extensions.annotations.ExtensionPoint;
+import com.google.gerrit.extensions.common.ActionInfo;
+import com.google.gerrit.extensions.common.ChangeInfo;
+import com.google.gerrit.extensions.common.RevisionInfo;
+
+/**
+ * Extension point called during population of {@link ActionInfo} maps.
+ *
+ * <p>Each visitor may mutate the input {@link ActionInfo}, or filter it out of the map entirely.
+ * When multiple extensions are registered, the order in which they are executed is undefined.
+ */
+@ExtensionPoint
+public interface ActionVisitor {
+  /**
+   * Visit a change-level action.
+   *
+   * <p>Callers may mutate the input {@link ActionInfo}, or return false to omit the action from the
+   * map entirely. Inputs other than the {@link ActionInfo} should be considered immutable.
+   *
+   * @param name name of the action, as a key into the {@link ActionInfo} map returned by the REST
+   *     API.
+   * @param actionInfo action being visited; caller may mutate.
+   * @param changeInfo information about the change to which this action belongs; caller should
+   *     treat as immutable.
+   * @return true if the action should remain in the map, or false to omit it.
+   */
+  boolean visit(String name, ActionInfo actionInfo, ChangeInfo changeInfo);
+
+  /**
+   * Visit a revision-level action.
+   *
+   * <p>Callers may mutate the input {@link ActionInfo}, or return false to omit the action from the
+   * map entirely. Inputs other than the {@link ActionInfo} should be considered immutable.
+   *
+   * @param name name of the action, as a key into the {@link ActionInfo} map returned by the REST
+   *     API.
+   * @param actionInfo action being visited; caller may mutate.
+   * @param changeInfo information about the change to which this action belongs; caller should
+   *     treat as immutable.
+   * @param revisionInfo information about the revision to which this action belongs; caller should
+   *     treat as immutable.
+   * @return true if the action should remain in the map, or false to omit it.
+   */
+  boolean visit(
+      String name, ActionInfo actionInfo, ChangeInfo changeInfo, RevisionInfo revisionInfo);
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ApplyPatchInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ApplyPatchInput.java
@@ -1,0 +1,33 @@
+// Copyright (C) 2022 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+import com.google.gerrit.common.Nullable;
+
+/** Information about a patch to apply. */
+public class ApplyPatchInput {
+  /**
+   * Required. The patch to be applied.
+   *
+   * <p>Must be compatible with `git diff` output. For example, Gerrit API `Get Patch` output.
+   */
+  public String patch;
+
+  /**
+   * If {@code true}, the operation will succeed if a conflict is detected. Conflict markers will be
+   * added to the conflicting files.
+   */
+  @Nullable public Boolean allowConflicts;
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ApplyPatchPatchSetInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ApplyPatchPatchSetInput.java
@@ -1,0 +1,54 @@
+// Copyright (C) 2022 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+import com.google.gerrit.common.Nullable;
+import com.google.gerrit.extensions.api.accounts.AccountInput;
+import com.google.gerrit.extensions.client.ListChangesOption;
+import java.util.List;
+
+/** Information for creating a new patch set from a given patch. */
+public class ApplyPatchPatchSetInput {
+
+  /** The patch to be applied. */
+  public ApplyPatchInput patch;
+
+  /**
+   * The commit message for the new patch set. If not specified, a predefined message will be used.
+   */
+  @Nullable public String commitMessage;
+
+  /**
+   * 40-hex digit SHA-1 of the commit which will be the parent commit of the newly created patch
+   * set. If set, it must be a merged commit or a change revision on the destination branch.
+   * Otherwise, the target change's branch tip will be used.
+   */
+  @Nullable public String base;
+
+  /**
+   * The author of the new patch set. Must include both {@link AccountInput#name} and {@link
+   * AccountInput#email} fields.
+   */
+  @Nullable public AccountInput author;
+
+  @Nullable public List<ListChangesOption> responseFormatOptions;
+
+  /**
+   * If {@code true}, the revision will be amended by the patch. This will use the tree of the
+   * revision, apply the patch and create a new commit whose tree is the resulting tree of the
+   * operation and whose parent(s) are the parent(s) of the revision.
+   */
+  @Nullable public Boolean amend;
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ChangeApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ChangeApi.java
@@ -242,9 +242,18 @@ public interface ChangeApi {
 
   IncludedInInfo includedIn() throws RestApiException;
 
+  /**
+   * Upstream changed this convenience method's return type from {@link AddReviewerResult} to
+   * {@link ReviewerResult} (both delegate to a differently-typed {@code addReviewer} overload).
+   * Java doesn't allow two methods with the same name/parameter types but different return types,
+   * so keeping both isn't possible; this keeps the original return type (and the original
+   * delegation to the deprecated {@link #addReviewer(AddReviewerInput)}) for source/binary
+   * compatibility with existing callers of {@code addReviewer(String)}. Use {@link
+   * #addReviewer(ReviewerInput)} directly for the new upstream behavior.
+   */
   @CanIgnoreReturnValue
-  default ReviewerResult addReviewer(String reviewer) throws RestApiException {
-    ReviewerInput in = new ReviewerInput();
+  default AddReviewerResult addReviewer(String reviewer) throws RestApiException {
+    AddReviewerInput in = new AddReviewerInput();
     in.reviewer = reviewer;
     return addReviewer(in);
   }
@@ -692,6 +701,10 @@ public interface ChangeApi {
   @Deprecated
   List<AccountInfo> getPastAssignees() throws RestApiException;
 
+  /** @deprecated removed upstream along with the "assignee" feature (superseded by attention set). */
+  @Deprecated
+  AccountInfo deleteAssignee() throws RestApiException;
+
   /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
   @Deprecated
   Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException;
@@ -699,6 +712,14 @@ public interface ChangeApi {
   /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
   @Deprecated
   void ignore(boolean ignore) throws RestApiException;
+
+  /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
+  @Deprecated
+  boolean ignored() throws RestApiException;
+
+  /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
+  @Deprecated
+  void markAsReviewed(boolean reviewed) throws RestApiException;
 
   /**
    * A default implementation which allows source compatibility when adding new methods to the
@@ -1004,12 +1025,27 @@ public interface ChangeApi {
     }
 
     @Override
+    public AccountInfo deleteAssignee() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
     public Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
     public void ignore(boolean ignore) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public boolean ignored() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void markAsReviewed(boolean reviewed) throws RestApiException {
       throw new NotImplementedException();
     }
   }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ChangeApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ChangeApi.java
@@ -15,14 +15,39 @@
 package com.google.gerrit.extensions.api.changes;
 
 import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.common.Nullable;
 import com.google.gerrit.extensions.client.ListChangesOption;
 import com.google.gerrit.extensions.client.ReviewerState;
-import com.google.gerrit.extensions.common.*;
+import com.google.gerrit.extensions.common.AccountInfo;
+import com.google.gerrit.extensions.common.ChangeInfo;
+import com.google.gerrit.extensions.common.ChangeInfoDifference;
+import com.google.gerrit.extensions.common.ChangeMessageInfo;
+import com.google.gerrit.extensions.common.CommentInfo;
+import com.google.gerrit.extensions.common.CommitMessageInfo;
+import com.google.gerrit.extensions.common.CommitMessageInput;
+import com.google.gerrit.extensions.common.EditInfo;
+import com.google.gerrit.extensions.common.EvaluateChangeQueryExpressionResultInfo;
+import com.google.gerrit.extensions.common.FlowActionTypeInfo;
+import com.google.gerrit.extensions.common.FlowInfo;
+import com.google.gerrit.extensions.common.FlowInput;
+import com.google.gerrit.extensions.common.IsFlowsEnabledInfo;
+import com.google.gerrit.extensions.common.MergePatchSetInput;
+import com.google.gerrit.extensions.common.PureRevertInfo;
+import com.google.gerrit.extensions.common.RebaseChainInfo;
+import com.google.gerrit.extensions.common.RevertSubmissionInfo;
+import com.google.gerrit.extensions.common.RobotCommentInfo;
+import com.google.gerrit.extensions.common.SubmitRequirementInput;
+import com.google.gerrit.extensions.common.SubmitRequirementResultInfo;
+import com.google.gerrit.extensions.common.SuggestedReviewerInfo;
+import com.google.gerrit.extensions.common.ValidationOptionInfos;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
+import com.google.gerrit.extensions.restapi.Response;
 import com.google.gerrit.extensions.restapi.RestApiException;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +101,23 @@ public interface ChangeApi {
    */
   ReviewerApi reviewer(String id) throws RestApiException;
 
+  /** Creates a new flow on the change. */
+  @CanIgnoreReturnValue
+  FlowInfo createFlow(FlowInput flowInput) throws RestApiException;
+
+  /** Look up a flow of this change by its UUID. */
+  FlowApi flow(String flowUuid) throws RestApiException;
+
+  IsFlowsEnabledInfo isFlowsEnabled() throws RestApiException;
+
+  /** Get the flows of this change/ */
+  List<FlowInfo> flows() throws RestApiException;
+
+  /** Get the actions of this change/ */
+  List<FlowActionTypeInfo> flowsActions() throws RestApiException;
+
+  EvaluateChangeQueryExpressionRequest evaluateChangeQueryExpression();
+
   default void abandon() throws RestApiException {
     abandon(new AbandonInput());
   }
@@ -115,32 +157,11 @@ public interface ChangeApi {
   }
 
   /**
-   * Ignore or un-ignore this change.
-   *
-   * @param ignore ignore the change if true
-   */
-  void ignore(boolean ignore) throws RestApiException;
-
-  /**
-   * Check if this change is ignored.
-   *
-   * @return true if the change is ignored
-   */
-  boolean ignored() throws RestApiException;
-
-  /**
-   * Mark this change as reviewed/unreviewed.
-   *
-   * @param reviewed flag to decide if this change should be marked as reviewed ({@code true}) or
-   *     unreviewed ({@code false})
-   */
-  void markAsReviewed(boolean reviewed) throws RestApiException;
-
-  /**
    * Create a new change that reverts this change.
    *
-   * @see Changes#id(int)
+   * @see Changes#id(String, int)
    */
+  @CanIgnoreReturnValue
   default ChangeApi revert() throws RestApiException {
     return revert(new RevertInput());
   }
@@ -148,18 +169,25 @@ public interface ChangeApi {
   /**
    * Create a new change that reverts this change.
    *
-   * @see Changes#id(int)
+   * @see Changes#id(String, int)
    */
+  @CanIgnoreReturnValue
   ChangeApi revert(RevertInput in) throws RestApiException;
 
+  @CanIgnoreReturnValue
   default RevertSubmissionInfo revertSubmission() throws RestApiException {
     return revertSubmission(new RevertInput());
   }
 
+  @CanIgnoreReturnValue
   RevertSubmissionInfo revertSubmission(RevertInput in) throws RestApiException;
 
   /** Create a merge patch set for the change. */
+  @CanIgnoreReturnValue
   ChangeInfo createMergePatchSet(MergePatchSetInput in) throws RestApiException;
+
+  @CanIgnoreReturnValue
+  ChangeInfo applyPatch(ApplyPatchPatchSetInput in) throws RestApiException;
 
   default List<ChangeInfo> submittedTogether() throws RestApiException {
     SubmittedTogetherInfo info =
@@ -177,10 +205,6 @@ public interface ChangeApi {
       EnumSet<ListChangesOption> listOptions, EnumSet<SubmittedTogetherOption> submitOptions)
       throws RestApiException;
 
-  /** Publishes a draft change. */
-  @Deprecated
-  void publish() throws RestApiException;
-
   /** Rebase the current revision of a change using default options. */
   default void rebase() throws RestApiException {
     rebase(new RebaseInput());
@@ -189,6 +213,26 @@ public interface ChangeApi {
   /** Rebase the current revision of a change. */
   void rebase(RebaseInput in) throws RestApiException;
 
+  /**
+   * Rebase the current revisions of a change's chain using default options.
+   *
+   * @return a {@code RebaseChainInfo} contains the {@code ChangeInfo} data for the rebased the
+   *     chain
+   */
+  @CanIgnoreReturnValue
+  default Response<RebaseChainInfo> rebaseChain() throws RestApiException {
+    return rebaseChain(new RebaseInput());
+  }
+
+  /**
+   * Rebase the current revisions of a change's chain.
+   *
+   * @return a {@code RebaseChainInfo} contains the {@code ChangeInfo} data for the rebased the
+   *     chain
+   */
+  @CanIgnoreReturnValue
+  Response<RebaseChainInfo> rebaseChain(RebaseInput in) throws RestApiException;
+
   /** Deletes a change. */
   void delete() throws RestApiException;
 
@@ -196,17 +240,17 @@ public interface ChangeApi {
 
   void topic(String topic) throws RestApiException;
 
-  List<ReviewerInfo> listReviewers() throws RestApiException;
-
   IncludedInInfo includedIn() throws RestApiException;
 
-  default AddReviewerResult addReviewer(String reviewer) throws RestApiException {
-    AddReviewerInput in = new AddReviewerInput();
+  @CanIgnoreReturnValue
+  default ReviewerResult addReviewer(String reviewer) throws RestApiException {
+    ReviewerInput in = new ReviewerInput();
     in.reviewer = reviewer;
     return addReviewer(in);
   }
 
-  AddReviewerResult addReviewer(AddReviewerInput in) throws RestApiException;
+  @CanIgnoreReturnValue
+  ReviewerResult addReviewer(ReviewerInput in) throws RestApiException;
 
   SuggestedReviewersRequest suggestReviewers() throws RestApiException;
 
@@ -257,19 +301,50 @@ public interface ChangeApi {
         EnumSet.complementOf(EnumSet.of(ListChangesOption.CHECK, ListChangesOption.SKIP_DIFFSTAT)));
   }
 
+  default ChangeInfoDifference metaDiff(
+      @Nullable String oldMetaRevId, @Nullable String newMetaRevId) throws RestApiException {
+    return metaDiff(
+        oldMetaRevId,
+        newMetaRevId,
+        EnumSet.noneOf(ListChangesOption.class),
+        ImmutableListMultimap.of());
+  }
+
+  default ChangeInfoDifference metaDiff(
+      @Nullable String oldMetaRevId, @Nullable String newMetaRevId, ListChangesOption... options)
+      throws RestApiException {
+    return metaDiff(oldMetaRevId, newMetaRevId, Arrays.asList(options));
+  }
+
+  default ChangeInfoDifference metaDiff(
+      @Nullable String oldMetaRevId,
+      @Nullable String newMetaRevId,
+      Collection<ListChangesOption> options)
+      throws RestApiException {
+    return metaDiff(
+        oldMetaRevId,
+        newMetaRevId,
+        Sets.newEnumSet(options, ListChangesOption.class),
+        ImmutableListMultimap.of());
+  }
+
+  /**
+   * Gets the diff between a change's metadata with the two given refs.
+   *
+   * @param oldMetaRevId the SHA-1 of the 'before' metadata diffed against {@code newMetaRevId}
+   * @param newMetaRevId the SHA-1 of the 'after' metadata diffed against {@code oldMetaRevId}
+   */
+  ChangeInfoDifference metaDiff(
+      @Nullable String oldMetaRevId,
+      @Nullable String newMetaRevId,
+      EnumSet<ListChangesOption> options,
+      ImmutableListMultimap<String, String> pluginOptions)
+      throws RestApiException;
+
   /** {@link #get(ListChangesOption...)} with no options included. */
   default ChangeInfo info() throws RestApiException {
     return get(EnumSet.noneOf(ListChangesOption.class));
   }
-
-  /**
-   * Retrieve change edit when exists.
-   *
-   * @deprecated Replaced by {@link ChangeApi#edit()} in combination with {@link
-   *     ChangeEditApi#get()}.
-   */
-  @Deprecated
-  EditInfo getEdit() throws RestApiException;
 
   /**
    * Provides access to an API regarding the change edit of this change.
@@ -278,6 +353,8 @@ public interface ChangeApi {
    * @throws RestApiException if the API isn't accessible
    */
   ChangeEditApi edit() throws RestApiException;
+
+  CommitMessageInfo getMessage() throws RestApiException;
 
   /** Create a new patch set with a new commit message. */
   default void setMessage(String message) throws RestApiException {
@@ -296,9 +373,25 @@ public interface ChangeApi {
    * Get hashtags on a change.
    *
    * @return hashtags
-   * @throws RestApiException
    */
   Set<String> getHashtags() throws RestApiException;
+
+  /** Set custom keyed values on a change */
+  void setCustomKeyedValues(CustomKeyedValuesInput input) throws RestApiException;
+
+  /**
+   * Gets the custom keyed values on a change.
+   *
+   * @return customKeyedValues
+   */
+  ImmutableMap<String, String> getCustomKeyedValues() throws RestApiException;
+
+  /**
+   * Gets the validation options on a change.
+   *
+   * @return validationOptions
+   */
+  ValidationOptionInfos getValidationOptions() throws RestApiException;
 
   /**
    * Manage the attention set.
@@ -308,86 +401,124 @@ public interface ChangeApi {
   AttentionSetApi attention(String id) throws RestApiException;
 
   /** Adds a user to the attention set. */
+  @CanIgnoreReturnValue
   AccountInfo addToAttentionSet(AttentionSetInput input) throws RestApiException;
-
-  /** Set the assignee of a change. */
-  AccountInfo setAssignee(AssigneeInput input) throws RestApiException;
-
-  /** Get the assignee of a change. */
-  AccountInfo getAssignee() throws RestApiException;
-
-  /** Get all past assignees. */
-  List<AccountInfo> getPastAssignees() throws RestApiException;
-
-  /**
-   * Delete the assignee of a change.
-   *
-   * @return the assignee that was deleted, or null if there was no assignee.
-   */
-  AccountInfo deleteAssignee() throws RestApiException;
 
   /**
    * Get all published comments on a change.
    *
    * @return comments in a map keyed by path; comments have the {@code revision} field set to
    *     indicate their patch set.
-   * @throws RestApiException
+   * @deprecated Callers should use {@link #commentsRequest()} instead
    */
-  Map<String, List<CommentInfo>> comments() throws RestApiException;
+  @Deprecated
+  default Map<String, List<CommentInfo>> comments() throws RestApiException {
+    return commentsRequest().get();
+  }
 
   /**
    * Get all published comments on a change as a list.
    *
    * @return comments as a list; comments have the {@code revision} field set to indicate their
    *     patch set.
-   * @throws RestApiException
+   * @deprecated Callers should use {@link #commentsRequest()} instead
    */
-  List<CommentInfo> commentsAsList() throws RestApiException;
+  @Deprecated
+  default List<CommentInfo> commentsAsList() throws RestApiException {
+    return commentsRequest().getAsList();
+  }
 
   /**
-   * Get all robot comments on a change.
+   * Get a {@link CommentsRequest} entity that can be used to retrieve published comments.
    *
-   * @return robot comments in a map keyed by path; robot comments have the {@code revision} field
-   *     set to indicate their patch set.
-   * @throws RestApiException
+   * @return A {@link CommentsRequest} entity that can be used to retrieve the comments using the
+   *     {@link CommentsRequest#get()} or {@link CommentsRequest#getAsList()}.
    */
-  Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException;
+  CommentsRequest commentsRequest() throws RestApiException;
 
   /**
    * Get all draft comments for the current user on a change.
    *
    * @return drafts in a map keyed by path; comments have the {@code revision} field set to indicate
    *     their patch set.
-   * @throws RestApiException
    */
-  Map<String, List<CommentInfo>> drafts() throws RestApiException;
+  default Map<String, List<CommentInfo>> drafts() throws RestApiException {
+    return draftsRequest().get();
+  }
 
   /**
    * Get all draft comments for the current user on a change as a list.
    *
    * @return drafts as a list; comments have the {@code revision} field set to indicate their patch
    *     set.
-   * @throws RestApiException
    */
-  List<CommentInfo> draftsAsList() throws RestApiException;
+  default List<CommentInfo> draftsAsList() throws RestApiException {
+    return draftsRequest().getAsList();
+  }
+
+  /**
+   * Get a {@link DraftsRequest} entity that can be used to retrieve draft comments.
+   *
+   * @return A {@link DraftsRequest} entity that can be used to retrieve the draft comments using
+   *     {@link DraftsRequest#get()} or {@link DraftsRequest#getAsList()}.
+   */
+  DraftsRequest draftsRequest() throws RestApiException;
 
   ChangeInfo check() throws RestApiException;
 
   ChangeInfo check(FixInput fix) throws RestApiException;
 
+  abstract class CheckSubmitRequirementRequest {
+    /** Submit requirement name. */
+    private String name;
+
+    /**
+     * A change ID for a change in {@link com.google.gerrit.entities.RefNames#REFS_CONFIG} branch
+     * from which the submit-requirement will be loaded.
+     */
+    private String refsConfigChangeId;
+
+    public abstract SubmitRequirementResultInfo get() throws RestApiException;
+
+    public CheckSubmitRequirementRequest srName(String srName) {
+      this.name = srName;
+      return this;
+    }
+
+    public CheckSubmitRequirementRequest refsConfigChangeId(String changeId) {
+      this.refsConfigChangeId = changeId;
+      return this;
+    }
+
+    protected String srName() {
+      return name;
+    }
+
+    protected String getRefsConfigChangeId() {
+      return refsConfigChangeId;
+    }
+  }
+
+  CheckSubmitRequirementRequest checkSubmitRequirementRequest() throws RestApiException;
+
+  /** Returns the result of evaluating the {@link SubmitRequirementInput} input on the change. */
+  SubmitRequirementResultInfo checkSubmitRequirement(SubmitRequirementInput input)
+      throws RestApiException;
+
   void index() throws RestApiException;
 
   /** Check if this change is a pure revert of the change stored in revertOf. */
+  @CanIgnoreReturnValue
   PureRevertInfo pureRevert() throws RestApiException;
 
   /** Check if this change is a pure revert of claimedOriginal (SHA1 in 40 digit hex). */
+  @CanIgnoreReturnValue
   PureRevertInfo pureRevert(String claimedOriginal) throws RestApiException;
 
   /**
    * Get all messages of a change with detailed account info.
    *
    * @return a list of messages sorted by their creation time.
-   * @throws RestApiException
    */
   List<ChangeMessageInfo> messages() throws RestApiException;
 
@@ -400,6 +531,52 @@ public interface ChangeApi {
    * @throws RestApiException if the id is invalid.
    */
   ChangeMessageApi message(String id) throws RestApiException;
+
+  abstract class CommentsRequest {
+    private boolean enableContext;
+    private int contextPadding;
+
+    /**
+     * Get all published comments on a change.
+     *
+     * @return comments in a map keyed by path; comments have the {@code revision} field set to
+     *     indicate their patch set.
+     */
+    public abstract Map<String, List<CommentInfo>> get() throws RestApiException;
+
+    /**
+     * Get all published comments on a change as a list.
+     *
+     * @return comments as a list; comments have the {@code revision} field set to indicate their
+     *     patch set.
+     */
+    public abstract List<CommentInfo> getAsList() throws RestApiException;
+
+    public CommentsRequest withContext(boolean enableContext) {
+      this.enableContext = enableContext;
+      return this;
+    }
+
+    public CommentsRequest contextPadding(int contextPadding) {
+      this.contextPadding = contextPadding;
+      return this;
+    }
+
+    public CommentsRequest withContext() {
+      this.enableContext = true;
+      return this;
+    }
+
+    public boolean getContext() {
+      return enableContext;
+    }
+
+    public int getContextPadding() {
+      return contextPadding;
+    }
+  }
+
+  abstract class DraftsRequest extends CommentsRequest {}
 
   abstract class SuggestedReviewersRequest {
     private String query;
@@ -446,6 +623,83 @@ public interface ChangeApi {
     }
   }
 
+  abstract class EvaluateChangeQueryExpressionRequest {
+    private String expression;
+    private boolean useIndex;
+
+    public abstract EvaluateChangeQueryExpressionResultInfo get() throws RestApiException;
+
+    public EvaluateChangeQueryExpressionRequest withExpression(String expression) {
+      this.expression = expression;
+      return this;
+    }
+
+    public EvaluateChangeQueryExpressionRequest useIndex() {
+      return useIndex(true);
+    }
+
+    public EvaluateChangeQueryExpressionRequest useIndex(boolean useIndex) {
+      this.useIndex = useIndex;
+      return this;
+    }
+
+    public String getExpression() {
+      return expression;
+    }
+
+    public boolean getUseIndex() {
+      return useIndex;
+    }
+  }
+
+  // The methods below were removed from this interface upstream (mostly because the features they
+  // exposed, e.g. draft changes and change assignees, were removed from Gerrit itself). They are
+  // kept here, deprecated, so that source and binary compatibility is preserved for existing
+  // implementers/callers of this interface.
+
+  /** @deprecated removed upstream along with the "draft change" feature it published. */
+  @Deprecated
+  void publish() throws RestApiException;
+
+  /**
+   * @deprecated removed upstream in favor of {@link #reviewers()}, which this delegates to.
+   */
+  @Deprecated
+  List<ReviewerInfo> listReviewers() throws RestApiException;
+
+  /**
+   * @deprecated removed upstream in favor of {@link #addReviewer(ReviewerInput)}.
+   */
+  @Deprecated
+  @CanIgnoreReturnValue
+  AddReviewerResult addReviewer(AddReviewerInput in) throws RestApiException;
+
+  /**
+   * @deprecated removed upstream in favor of {@link #edit()} and {@link ChangeEditApi#get()}.
+   */
+  @Deprecated
+  EditInfo getEdit() throws RestApiException;
+
+  /** @deprecated removed upstream along with the "assignee" feature (superseded by attention set). */
+  @Deprecated
+  AccountInfo setAssignee(AssigneeInput input) throws RestApiException;
+
+  /** @deprecated removed upstream along with the "assignee" feature (superseded by attention set). */
+  @Deprecated
+  AccountInfo getAssignee() throws RestApiException;
+
+  /** @deprecated removed upstream along with the "assignee" feature (superseded by attention set). */
+  @Deprecated
+  List<AccountInfo> getPastAssignees() throws RestApiException;
+
+  /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
+  @Deprecated
+  Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException;
+
+  /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
+  @Deprecated
+  void ignore(boolean ignore) throws RestApiException;
+
   /**
    * A default implementation which allows source compatibility when adding new methods to the
    * interface.
@@ -457,12 +711,42 @@ public interface ChangeApi {
     }
 
     @Override
+    public RevisionApi revision(String id) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
     public ReviewerApi reviewer(String id) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    public RevisionApi revision(String id) throws RestApiException {
+    public FlowInfo createFlow(FlowInput flowInput) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public FlowApi flow(String flowUuid) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public IsFlowsEnabledInfo isFlowsEnabled() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public List<FlowInfo> flows() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public List<FlowActionTypeInfo> flowsActions() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public EvaluateChangeQueryExpressionRequest evaluateChangeQueryExpression() {
       throw new NotImplementedException();
     }
 
@@ -487,12 +771,12 @@ public interface ChangeApi {
     }
 
     @Override
-    public void setWorkInProgress(String message) throws RestApiException {
+    public void setWorkInProgress(@Nullable String message) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    public void setReadyForReview(String message) throws RestApiException {
+    public void setReadyForReview(@Nullable String message) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -507,12 +791,27 @@ public interface ChangeApi {
     }
 
     @Override
-    public void publish() throws RestApiException {
+    public ChangeInfo createMergePatchSet(MergePatchSetInput in) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public ChangeInfo applyPatch(ApplyPatchPatchSetInput in) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public SubmittedTogetherInfo submittedTogether(EnumSet<ListChangesOption> listOptions, EnumSet<SubmittedTogetherOption> submitOptions) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
     public void rebase(RebaseInput in) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Response<RebaseChainInfo> rebaseChain(RebaseInput in) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -537,12 +836,7 @@ public interface ChangeApi {
     }
 
     @Override
-    public List<ReviewerInfo> listReviewers() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public AddReviewerResult addReviewer(AddReviewerInput in) throws RestApiException {
+    public ReviewerResult addReviewer(ReviewerInput in) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -552,34 +846,35 @@ public interface ChangeApi {
     }
 
     @Override
-    public SuggestedReviewersRequest suggestReviewers(String query) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
     public List<ReviewerInfo> reviewers() throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    public ChangeInfo get(
-        EnumSet<ListChangesOption> options, ImmutableListMultimap<String, String> pluginOptions)
-        throws RestApiException {
+    public ChangeInfo get(EnumSet<ListChangesOption> options, ImmutableListMultimap<String, String> pluginOptions) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    public void setMessage(CommitMessageInput in) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public EditInfo getEdit() throws RestApiException {
+    public ChangeInfoDifference metaDiff(@Nullable String oldMetaRevId,
+      @Nullable String newMetaRevId,
+      EnumSet<ListChangesOption> options,
+      ImmutableListMultimap<String, String> pluginOptions) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
     public ChangeEditApi edit() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public CommitMessageInfo getMessage() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void setMessage(CommitMessageInput in) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -594,6 +889,21 @@ public interface ChangeApi {
     }
 
     @Override
+    public void setCustomKeyedValues(CustomKeyedValuesInput input) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public ImmutableMap<String, String> getCustomKeyedValues() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public ValidationOptionInfos getValidationOptions() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
     public AttentionSetApi attention(String id) throws RestApiException {
       throw new NotImplementedException();
     }
@@ -604,47 +914,12 @@ public interface ChangeApi {
     }
 
     @Override
-    public AccountInfo setAssignee(AssigneeInput input) throws RestApiException {
+    public CommentsRequest commentsRequest() throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    public AccountInfo getAssignee() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public List<AccountInfo> getPastAssignees() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public AccountInfo deleteAssignee() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public Map<String, List<CommentInfo>> comments() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public List<CommentInfo> commentsAsList() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public Map<String, List<CommentInfo>> drafts() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public List<CommentInfo> draftsAsList() throws RestApiException {
+    public DraftsRequest draftsRequest() throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -659,44 +934,17 @@ public interface ChangeApi {
     }
 
     @Override
+    public CheckSubmitRequirementRequest checkSubmitRequirementRequest() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public SubmitRequirementResultInfo checkSubmitRequirement(SubmitRequirementInput input) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
     public void index() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public List<ChangeInfo> submittedTogether() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public SubmittedTogetherInfo submittedTogether(EnumSet<SubmittedTogetherOption> options)
-        throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public SubmittedTogetherInfo submittedTogether(
-        EnumSet<ListChangesOption> a, EnumSet<SubmittedTogetherOption> b) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public ChangeInfo createMergePatchSet(MergePatchSetInput in) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public void ignore(boolean ignore) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public boolean ignored() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public void markAsReviewed(boolean reviewed) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -717,6 +965,51 @@ public interface ChangeApi {
 
     @Override
     public ChangeMessageApi message(String id) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void publish() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public List<ReviewerInfo> listReviewers() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public AddReviewerResult addReviewer(AddReviewerInput in) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public EditInfo getEdit() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public AccountInfo setAssignee(AssigneeInput input) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public AccountInfo getAssignee() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public List<AccountInfo> getPastAssignees() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void ignore(boolean ignore) throws RestApiException {
       throw new NotImplementedException();
     }
   }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ChangeEditApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ChangeEditApi.java
@@ -91,6 +91,14 @@ public interface ChangeEditApi {
   void rebase() throws RestApiException;
 
   /**
+   * Rebases the change edit on top of the latest patch set of this change.
+   *
+   * @param input params for rebasing the change edit
+   * @throws RestApiException if the change edit couldn't be rebased or a change edit wasn't present
+   */
+  EditInfo rebase(RebaseChangeEditInput input) throws RestApiException;
+
+  /**
    * Publishes the change edit using default settings. See {@link #publish(PublishChangeEditInput)}
    * for more details.
    *
@@ -196,6 +204,18 @@ public interface ChangeEditApi {
   void modifyCommitMessage(String newCommitMessage) throws RestApiException;
 
   /**
+   * Updates the author/committer of the change edit. If the change edit doesn't exist, it will be
+   * created based on the current patch set of the change.
+   *
+   * @param name the name of the author/committer
+   * @param email the email of the author/committer
+   * @param type the type of the identity being edited
+   * @throws RestApiException if the author/committer identity couldn't be updated
+   */
+  void modifyIdentity(String name, String email, ChangeEditIdentityType type)
+      throws RestApiException;
+
+  /**
    * A default implementation which allows source compatibility when adding new methods to the
    * interface.
    */
@@ -222,6 +242,11 @@ public interface ChangeEditApi {
 
     @Override
     public void rebase() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public EditInfo rebase(RebaseChangeEditInput input) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -267,6 +292,11 @@ public interface ChangeEditApi {
 
     @Override
     public void modifyCommitMessage(String newCommitMessage) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void modifyIdentity(String name, String email, ChangeEditIdentityType type) throws RestApiException {
       throw new NotImplementedException();
     }
   }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ChangeEditIdentityType.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ChangeEditIdentityType.java
@@ -1,0 +1,20 @@
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+public enum ChangeEditIdentityType {
+  AUTHOR,
+  COMMITTER
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ChangeIdentifier.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ChangeIdentifier.java
@@ -1,0 +1,112 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import java.util.Objects;
+
+/**
+ * Identifier for a change to be used in the {@link Changes} API to get the {@link ChangeApi} for a
+ * change.
+ *
+ * <p>Supports any change identifier that is supported by the REST API, including {@code
+ * <project>~<changeNumber>}, {@code <changeId>} (I-hash), {@code <project>~<branch>~<changeId>}
+ * (aka as triplet) and {@code <changeNumber>} (numeric change ID).
+ */
+public final class ChangeIdentifier {
+  private final String id;
+
+  private ChangeIdentifier(String id) {
+    this.id = id;
+  }
+
+  public String id() {
+    return id;
+  }
+
+  @Override
+  public final String toString() {
+    return id();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof ChangeIdentifier)) {
+      return false;
+    }
+    return id.equals(((ChangeIdentifier) o).id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id);
+  }
+
+  /**
+   * Creates a change identifier in the format {@code <project>~<changeNumber>}.
+   *
+   * <p>Always uniquely identifies one change.
+   *
+   * <p>This is the preferred identifier for identifying changes.
+   *
+   * @param projectName the name of the project that contains the change
+   * @param numericChangeId the numeric change ID (aka as change number)
+   */
+  public static ChangeIdentifier byProjectAndNumericChangeId(
+      String projectName, int numericChangeId) {
+    return new ChangeIdentifier(projectName + "~" + numericChangeId);
+  }
+
+  /**
+   * Creates a change identifier in the format {@code <project>~<branch>~<changeId>}.
+   *
+   * <p>Always uniquely identifies one change.
+   *
+   * @param projectName the name of the project that contains the change
+   * @param branchName the name of the branch that contains the change, may be the short branch name
+   *     without the {@code refs/heads/} prefix.
+   * @param changeId the I-hash of the change
+   */
+  public static ChangeIdentifier byTriplet(String projectName, String branchName, String changeId) {
+    checkState(changeId.startsWith("I"), "expected changeId to be the I-hash");
+    return new ChangeIdentifier(projectName + "~" + branchName + "~" + changeId);
+  }
+
+  /**
+   * Creates a change identifier in the format {@code <changeId>}.
+   *
+   * <p>May not always identify a single change (e.g. it matches multiple changes if a change has
+   * been cherry-picked).
+   *
+   * @param changeId the I-hash of the change
+   */
+  public static ChangeIdentifier byChangeId(String changeId) {
+    checkState(changeId.startsWith("I"), "expected changeId to be the I-hash");
+    return new ChangeIdentifier(changeId);
+  }
+
+  /**
+   * Creates a change identifier in the format {@code <changeNumber>}.
+   *
+   * <p>May not always identify a single change (e.g. when changes have been imported from another
+   * Gerrit instance).
+   *
+   * @param numericChangeId the numeric change ID (aka as change number)
+   */
+  public static ChangeIdentifier byNumericChangeId(int numericChangeId) {
+    return new ChangeIdentifier(Integer.valueOf(numericChangeId).toString());
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ChangeIdentifier.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ChangeIdentifier.java
@@ -16,6 +16,7 @@ package com.google.gerrit.extensions.api.changes;
 
 import static com.google.common.base.Preconditions.checkState;
 
+import com.google.gerrit.extensions.restapi.Url;
 import java.util.Objects;
 
 /**
@@ -67,7 +68,7 @@ public final class ChangeIdentifier {
    */
   public static ChangeIdentifier byProjectAndNumericChangeId(
       String projectName, int numericChangeId) {
-    return new ChangeIdentifier(projectName + "~" + numericChangeId);
+    return new ChangeIdentifier(Url.encode(projectName) + "~" + numericChangeId);
   }
 
   /**
@@ -82,7 +83,8 @@ public final class ChangeIdentifier {
    */
   public static ChangeIdentifier byTriplet(String projectName, String branchName, String changeId) {
     checkState(changeId.startsWith("I"), "expected changeId to be the I-hash");
-    return new ChangeIdentifier(projectName + "~" + branchName + "~" + changeId);
+    return new ChangeIdentifier(
+        Url.encode(projectName) + "~" + Url.encode(branchName) + "~" + changeId);
   }
 
   /**

--- a/src/main/java/com/google/gerrit/extensions/api/changes/Changes.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/Changes.java
@@ -16,13 +16,14 @@ package com.google.gerrit.extensions.api.changes;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.gerrit.common.UsedAt;
 import com.google.gerrit.extensions.client.ListChangesOption;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.ChangeInput;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
 import com.google.gwtorm.server.StandardKeyEncoder;
-
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.List;
@@ -32,21 +33,21 @@ public interface Changes {
   /**
    * Look up a change by numeric ID.
    *
-   * <p><strong>Note:</strong> This method eagerly reads the change. Methods that mutate the change
-   * do not necessarily re-read the change. Therefore, calling a getter method on an instance after
-   * calling a mutation method on that same instance is not guaranteed to reflect the mutation. It
-   * is not recommended to store references to {@code ChangeApi} instances.
+   * <p><strong>Note:</strong> Change number is not guaranteed to unambiguously identify a change.
    *
+   * @see #id(String, int)
+   * @deprecated in favor of {@link #id(String, int)}
    * @param id change number.
    * @return API for accessing the change.
    * @throws RestApiException if an error occurred.
    */
+  @Deprecated(since = "3.9")
   ChangeApi id(int id) throws RestApiException;
 
   /**
    * Look up a change by string ID.
    *
-   * @see #id(int)
+   * @see #id(String, int)
    * @param id any identifier supported by the REST API, including change number, Change-Id, or
    *     project~branch~Change-Id triplet.
    * @return API for accessing the change.
@@ -57,19 +58,39 @@ public interface Changes {
   /**
    * Look up a change by project, branch, and change ID.
    *
-   * @see #id(int)
+   * @see #id(String, int)
    */
   ChangeApi id(String project, String branch, String id) throws RestApiException;
 
   /**
    * Look up a change by project and numeric ID.
    *
+   * <p><strong>Note:</strong> This method eagerly reads the change. Methods that mutate the change
+   * do not necessarily re-read the change. Therefore, calling a getter method on an instance after
+   * calling a mutation method on that same instance is not guaranteed to reflect the mutation. It
+   * is not recommended to store references to {@code ChangeApi} instances. Also note that the
+   * change numeric id without a project name parameter may fail to identify a unique change
+   * element, because the potential conflict with other changes imported from Gerrit instances with
+   * a different Server-Id.
+   *
    * @param project project name.
    * @param id change number.
-   * @see #id(int)
    */
   ChangeApi id(String project, int id) throws RestApiException;
 
+  /**
+   * Look up a change by the given change identifier.
+   *
+   * @see #id(String)
+   * @param changeIdentifier identifier that identifies a change
+   * @return API for accessing the change.
+   * @throws RestApiException if an error occurred.
+   */
+  default ChangeApi id(ChangeIdentifier changeIdentifier) throws RestApiException {
+    return id(changeIdentifier.id());
+  }
+
+  @CanIgnoreReturnValue
   ChangeApi create(ChangeInput in) throws RestApiException;
 
   ChangeInfo createAsInfo(ChangeInput in) throws RestApiException;
@@ -82,8 +103,11 @@ public interface Changes {
     private String query;
     private int limit;
     private int start;
-    private String sortkey; // server version < 2.9, needed for change list paging
     private boolean isNoLimit;
+    private boolean allowIncompleteResults;
+    // Removed upstream (server version < 2.9, needed for change list paging). Kept here, deprecated,
+    // for source/binary compatibility with existing callers.
+    @Deprecated private String sortkey;
     private Set<ListChangesOption> options = EnumSet.noneOf(ListChangesOption.class);
     private ListMultimap<String, String> pluginOptions = ArrayListMultimap.create();
 
@@ -94,6 +118,11 @@ public interface Changes {
       return this;
     }
 
+    /**
+     * @deprecated removed upstream; kept for source/binary compatibility with existing callers. URL
+     *     encodes the query string set via {@link #withQuery(String)}.
+     */
+    @Deprecated
     public QueryRequest encode() {
       query = StandardKeyEncoder.encode(query);
       return this;
@@ -114,9 +143,19 @@ public interface Changes {
       return this;
     }
 
-    // server version < 2.9, needed for change list paging
+    /**
+     * @deprecated removed upstream (server version &lt; 2.9, needed for change list paging); kept
+     *     for source/binary compatibility with existing callers.
+     */
+    @Deprecated
     public QueryRequest withSortkey(String sortkey) {
       this.sortkey = sortkey;
+      return this;
+    }
+
+    @UsedAt(UsedAt.Project.GOOGLE)
+    public QueryRequest withAllowIncompleteResults(boolean allow) {
+      this.allowIncompleteResults = allow;
       return this;
     }
 
@@ -166,9 +205,18 @@ public interface Changes {
       return start;
     }
 
-    // server version < 2.9, needed for change list paging
+    /**
+     * @deprecated removed upstream (server version &lt; 2.9, needed for change list paging); kept
+     *     for source/binary compatibility with existing callers.
+     */
+    @Deprecated
     public String getSortkey() {
       return sortkey;
+    }
+
+    @UsedAt(UsedAt.Project.GOOGLE)
+    public boolean getAllowIncompleteResults() {
+      return allowIncompleteResults;
     }
 
     public Set<ListChangesOption> getOptions() {
@@ -210,7 +258,7 @@ public interface Changes {
     }
 
     @Override
-    public ChangeApi id(String triplet) throws RestApiException {
+    public ChangeApi id(String id) throws RestApiException {
       throw new NotImplementedException();
     }
 

--- a/src/main/java/com/google/gerrit/extensions/api/changes/CherryPickInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/CherryPickInput.java
@@ -31,4 +31,6 @@ public class CherryPickInput {
   public boolean allowConflicts;
   public String topic;
   public boolean allowEmpty;
+  public Map<String, String> validationOptions;
+  public String committerEmail;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/CommentApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/CommentApi.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.extensions.api.changes;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.extensions.common.CommentInfo;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
@@ -30,6 +31,7 @@ public interface CommentApi {
    *
    * @return the comment with its message updated.
    */
+  @CanIgnoreReturnValue
   CommentInfo delete(DeleteCommentInput input) throws RestApiException;
 
   /**

--- a/src/main/java/com/google/gerrit/extensions/api/changes/CommentInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/CommentInput.java
@@ -1,0 +1,20 @@
+// Copyright (C) 2020 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+/** Input to the {@link ChangeApi#comments}. */
+public class CommentInput {
+  public boolean enableContext;
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/CustomKeyedValuesInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/CustomKeyedValuesInput.java
@@ -1,0 +1,35 @@
+// Copyright (C) 2023 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+import com.google.gerrit.extensions.restapi.DefaultInput;
+import java.util.Map;
+import java.util.Set;
+
+public class CustomKeyedValuesInput {
+  @DefaultInput public Map<String, String> add;
+  public Set<String> remove;
+
+  public CustomKeyedValuesInput() {}
+
+  public CustomKeyedValuesInput(Map<String, String> add) {
+    this.add = add;
+  }
+
+  public CustomKeyedValuesInput(Map<String, String> add, Set<String> remove) {
+    this(add);
+    this.remove = remove;
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/DeleteVoteInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/DeleteVoteInput.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.extensions.api.changes;
 
+import com.google.gerrit.common.Nullable;
 import com.google.gerrit.extensions.restapi.DefaultInput;
 import java.util.Map;
 
@@ -25,4 +26,13 @@ public class DeleteVoteInput {
   public NotifyHandling notify = NotifyHandling.ALL;
 
   public Map<RecipientType, NotifyInfo> notifyDetails;
+
+  /**
+   * Users in the attention set will not be added/removed from this endpoint call. Normally, users
+   * are added to the attention set upon deletion of their vote by other users.
+   */
+  public boolean ignoreAutomaticAttentionSetRules;
+
+  /** Reason for this vote deletion. Will appear in the change message. */
+  @Nullable public String reason;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/DraftApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/DraftApi.java
@@ -14,11 +14,13 @@
 
 package com.google.gerrit.extensions.api.changes;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.extensions.common.CommentInfo;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
 
 public interface DraftApi extends CommentApi {
+  @CanIgnoreReturnValue
   CommentInfo update(DraftInput in) throws RestApiException;
 
   void delete() throws RestApiException;
@@ -27,7 +29,7 @@ public interface DraftApi extends CommentApi {
    * A default implementation which allows source compatibility when adding new methods to the
    * interface.
    */
-  class NotImplemented extends CommentApi.NotImplemented implements DraftApi {
+  class NotImplemented implements DraftApi {
     @Override
     public CommentInfo update(DraftInput in) throws RestApiException {
       throw new NotImplementedException();
@@ -35,6 +37,16 @@ public interface DraftApi extends CommentApi {
 
     @Override
     public void delete() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public CommentInfo get() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public CommentInfo delete(DeleteCommentInput input) throws RestApiException {
       throw new NotImplementedException();
     }
   }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/DraftInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/DraftInput.java
@@ -19,18 +19,19 @@ import java.util.Objects;
 
 public class DraftInput extends Comment {
   public String tag;
+  public Boolean unresolved;
 
   @Override
   public boolean equals(Object o) {
     if (super.equals(o)) {
       DraftInput di = (DraftInput) o;
-      return Objects.equals(tag, di.tag);
+      return Objects.equals(tag, di.tag) && Objects.equals(unresolved, di.unresolved);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), tag);
+    return Objects.hash(super.hashCode(), tag, unresolved);
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/DraftInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/DraftInput.java
@@ -19,19 +19,18 @@ import java.util.Objects;
 
 public class DraftInput extends Comment {
   public String tag;
-  public Boolean unresolved;
 
   @Override
   public boolean equals(Object o) {
     if (super.equals(o)) {
       DraftInput di = (DraftInput) o;
-      return Objects.equals(tag, di.tag) && Objects.equals(unresolved, di.unresolved);
+      return Objects.equals(tag, di.tag);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), tag, unresolved);
+    return Objects.hash(super.hashCode(), tag);
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/FileApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/FileApi.java
@@ -29,10 +29,18 @@ public interface FileApi {
   /** Diff against the revision's parent version of the file. */
   DiffInfo diff() throws RestApiException;
 
-  /** @param base revision id of the revision to be used as the diff base */
+  /**
+   * Diff against the specified base
+   *
+   * @param base revision id of the revision to be used as the diff base
+   */
   DiffInfo diff(String base) throws RestApiException;
 
-  /** @param parent 1-based parent number to diff against */
+  /**
+   * Diff against the specified parent
+   *
+   * @param parent 1-based parent number to diff against
+   */
   DiffInfo diff(int parent) throws RestApiException;
 
   /**
@@ -52,7 +60,9 @@ public interface FileApi {
 
   abstract class DiffRequest {
     private String base;
-    private Integer context;
+    // Removed upstream. Kept here, deprecated, for source/binary compatibility with existing
+    // callers.
+    @Deprecated private Integer context;
     private Boolean intraline;
     private Whitespace whitespace;
     private OptionalInt parent = OptionalInt.empty();
@@ -64,6 +74,8 @@ public interface FileApi {
       return this;
     }
 
+    /** @deprecated removed upstream; kept for source/binary compatibility with existing callers. */
+    @Deprecated
     public DiffRequest withContext(int context) {
       this.context = context;
       return this;
@@ -88,6 +100,8 @@ public interface FileApi {
       return base;
     }
 
+    /** @deprecated removed upstream; kept for source/binary compatibility with existing callers. */
+    @Deprecated
     public Integer getContext() {
       return context;
     }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/FileContentInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/FileContentInput.java
@@ -20,5 +20,25 @@ import com.google.gerrit.extensions.restapi.RawInput;
 /** Content to be added to a file (new or existing) via change edit. */
 public class FileContentInput {
   @DefaultInput public RawInput content;
-  public String binary_content;
+
+  /**
+   * The file content as a base-64 encoded data URI.
+   *
+   * <p>If no content is provided, an empty is created or if an existing file is updated the file
+   * content is removed so that the file becomes empty.
+   *
+   * <p>The content must be a SHA1 if the file mode is {@code 160000} (gitlink).
+   */
+  public String binaryContent;
+
+  /**
+   * The file mode in octal format.
+   *
+   * <p>Supported values are {@code 100644} (regular file), {@code 100755} (executable file), {@code
+   * 120000} (symlink) and {@code 160000} (gitlink).
+   *
+   * <p>If unset, new files are created with file mode {@code 100644} (regular file) and for
+   * existing files the existing file mode is kept.
+   */
+  public Integer fileMode;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/FlowApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/FlowApi.java
@@ -1,0 +1,44 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+import com.google.gerrit.extensions.common.FlowInfo;
+import com.google.gerrit.extensions.restapi.NotImplementedException;
+import com.google.gerrit.extensions.restapi.RestApiException;
+
+/** API to call REST endpoints on flows. */
+public interface FlowApi {
+  /** Gets the flow. */
+  FlowInfo get() throws RestApiException;
+
+  /** Deletes a flow. */
+  void delete() throws RestApiException;
+
+  /**
+   * A default implementation which allows source compatibility when adding new methods to the
+   * interface.
+   */
+  class NotImplemented implements FlowApi {
+    @Override
+    public FlowInfo get() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void delete() throws RestApiException {
+      throw new NotImplementedException();
+    }
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/GetRelatedOption.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/GetRelatedOption.java
@@ -1,0 +1,21 @@
+// Copyright (C) 2022 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+/** Options for "Get Related Changes" requests. */
+public enum GetRelatedOption {
+  /** Compute submittability boolean for all returned changes. */
+  SUBMITTABLE
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/MoveInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/MoveInput.java
@@ -17,4 +17,15 @@ package com.google.gerrit.extensions.api.changes;
 public class MoveInput {
   public String message;
   public String destinationBranch;
+
+  /**
+   * Whether or not to keep all votes in the destination branch. Keeping the votes can be confusing
+   * in the context of the destination branch, see
+   * https://gerrit-review.googlesource.com/c/gerrit/+/129171. That is why only the users with
+   * {@link com.google.gerrit.server.permissions.GlobalPermission#ADMINISTRATE_SERVER} permissions
+   * can use this option.
+   *
+   * <p>By default, only the veto votes that are blocking the change from submission are moved.
+   */
+  public boolean keepAllVotes;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/NotifyHandling.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/NotifyHandling.java
@@ -15,8 +15,18 @@
 package com.google.gerrit.extensions.api.changes;
 
 public enum NotifyHandling {
-  NONE,
-  OWNER,
-  OWNER_REVIEWERS,
-  ALL
+  NONE(0),
+  OWNER(1),
+  OWNER_REVIEWERS(2),
+  ALL(3);
+
+  private final int value;
+
+  NotifyHandling(int v) {
+    this.value = v;
+  }
+
+  public int getValue() {
+    return value;
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/NotifyInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/NotifyInfo.java
@@ -15,10 +15,12 @@
 package com.google.gerrit.extensions.api.changes;
 
 import com.google.common.base.MoreObjects;
+import com.google.gerrit.common.ConvertibleToProto;
 import java.util.List;
 import java.util.Objects;
 
 /** Detailed information about who should be notified about an update. */
+@ConvertibleToProto
 public class NotifyInfo {
   public List<String> accounts;
 

--- a/src/main/java/com/google/gerrit/extensions/api/changes/RebaseChangeEditInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/RebaseChangeEditInput.java
@@ -1,0 +1,25 @@
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+public class RebaseChangeEditInput {
+  /**
+   * Whether the rebase should succeed if there are conflicts.
+   *
+   * <p>If there are conflicts the file contents of the rebased change contain git conflict markers
+   * to indicate the conflicts.
+   */
+  public boolean allowConflicts;
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/RebaseInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/RebaseInput.java
@@ -14,6 +14,49 @@
 
 package com.google.gerrit.extensions.api.changes;
 
+import java.util.Map;
+
 public class RebaseInput {
   public String base;
+
+  /**
+   * {@code strategy} name of the merge strategy.
+   *
+   * @see org.eclipse.jgit.merge.MergeStrategy
+   */
+  public String strategy;
+
+  /**
+   * Whether the rebase should succeed if there are conflicts.
+   *
+   * <p>If there are conflicts the file contents of the rebased change contain git conflict markers
+   * to indicate the conflicts.
+   */
+  public boolean allowConflicts;
+
+  /**
+   * Whether the rebase should be done on behalf of the uploader.
+   *
+   * <p>This means the uploader of the current patch set will also be the uploader of the rebased
+   * patch set. The calling user will be recorded as the real user.
+   *
+   * <p>Rebasing on behalf of the uploader is only supported for trivial rebases. This means this
+   * option cannot be combined with the {@link #allowConflicts} option.
+   *
+   * <p>In addition, rebasing on behalf of the uploader is only supported for the current patch set
+   * of a change and not when rebasing a chain.
+   *
+   * <p>Using this option is not supported when rebasing a chain via the Rebase Chain REST endpoint.
+   */
+  public boolean onBehalfOfUploader;
+
+  public Map<String, String> validationOptions;
+
+  /**
+   * Rebase will be committed using this email address. Only the registered emails of the calling
+   * user or uploader (when onBehalfOfUploader is true) are considered valid.
+   *
+   * <p>This option is not supported when rebasing a chain.
+   */
+  public String committerEmail;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/RecipientType.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/RecipientType.java
@@ -15,7 +15,17 @@
 package com.google.gerrit.extensions.api.changes;
 
 public enum RecipientType {
-  TO,
-  CC,
-  BCC
+  TO(0),
+  CC(1),
+  BCC(2);
+
+  private final int value;
+
+  RecipientType(int v) {
+    this.value = v;
+  }
+
+  public int getValue() {
+    return value;
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/RelatedChangeAndCommitInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/RelatedChangeAndCommitInfo.java
@@ -25,6 +25,8 @@ public class RelatedChangeAndCommitInfo {
   public Integer _revisionNumber;
   public Integer _currentRevisionNumber;
   public String status;
+  public Boolean submittable;
+  public Boolean workInProgress;
 
   public RelatedChangeAndCommitInfo() {}
 
@@ -38,6 +40,8 @@ public class RelatedChangeAndCommitInfo {
         .add("_revisionNumber", _revisionNumber)
         .add("_currentRevisionNumber", _currentRevisionNumber)
         .add("status", status)
+        .add("submittable", submittable)
+        .add("workInProgress", workInProgress)
         .toString();
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/RevertInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/RevertInput.java
@@ -17,6 +17,10 @@ package com.google.gerrit.extensions.api.changes;
 import com.google.gerrit.extensions.restapi.DefaultInput;
 import java.util.Map;
 
+/**
+ * Input passed to {@code POST /changes/[change-id]/revert} and {@code POST
+ * /changes/[change-id]/revert_submission}
+ */
 public class RevertInput {
   @DefaultInput public String message;
 
@@ -26,4 +30,16 @@ public class RevertInput {
   public Map<RecipientType, NotifyInfo> notifyDetails;
 
   public String topic;
+
+  /**
+   * Mark the change as work-in-progress. This will also override the {@link #notify} value to
+   * {@link NotifyHandling#OWNER}
+   */
+  public Boolean workInProgress;
+
+  public Map<String, String> validationOptions;
+
+  public boolean getWorkInProgress() {
+    return workInProgress != null ? workInProgress : false;
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ReviewInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ReviewInput.java
@@ -14,16 +14,21 @@
 
 package com.google.gerrit.extensions.api.changes;
 
+import static com.google.gerrit.extensions.client.ReviewerState.CC;
 import static com.google.gerrit.extensions.client.ReviewerState.REVIEWER;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.gerrit.common.Nullable;
 import com.google.gerrit.extensions.client.Comment;
+import com.google.gerrit.extensions.client.ListChangesOption;
 import com.google.gerrit.extensions.client.ReviewerState;
-import com.google.gerrit.extensions.common.FixSuggestionInfo;
 import com.google.gerrit.extensions.restapi.DefaultInput;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /** Input passed to {@code POST /changes/[id]/revisions/[id]/review}. */
 public class ReviewInput {
@@ -33,7 +38,9 @@ public class ReviewInput {
 
   public Map<String, Short> labels;
   public Map<String, List<CommentInput>> comments;
-  public Map<String, List<RobotCommentInput>> robotComments;
+
+  /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
+  @Deprecated public Map<String, List<RobotCommentInput>> robotComments;
 
   /**
    * How to process draft comments already in the database that were not also described in this
@@ -43,6 +50,9 @@ public class ReviewInput {
    * no other value besides {@code KEEP} is allowed.
    */
   public DraftHandling drafts;
+
+  /** A list of draft IDs that should be published. */
+  public List<String> draftIdsToPublish;
 
   /** Who to send email notifications to after review is stored. */
   public NotifyHandling notify;
@@ -60,8 +70,8 @@ public class ReviewInput {
    */
   public String onBehalfOf;
 
-  /** Reviewers that should be added to this change. */
-  public List<AddReviewerInput> reviewers;
+  /** Reviewers that should be added to this change or removed from it. */
+  public List<ReviewerInput> reviewers;
 
   /**
    * If true mark the change as work in progress. It is an error for both {@link #workInProgress}
@@ -89,6 +99,8 @@ public class ReviewInput {
    */
   public boolean ignoreAutomaticAttentionSetRules;
 
+  @Nullable public List<ListChangesOption> responseFormatOptions;
+
   public enum DraftHandling {
     /** Leave pending drafts alone. */
     KEEP,
@@ -100,21 +112,36 @@ public class ReviewInput {
     PUBLISH_ALL_REVISIONS
   }
 
-  public static class CommentInput extends Comment {}
+  public static class CommentInput extends Comment {
+    public Boolean unresolved;
+  }
 
+  /** @deprecated removed upstream; the underlying REST resource may still exist. */
+  @Deprecated
   public static class RobotCommentInput extends CommentInput {
     public String robotId;
     public String robotRunId;
     public String url;
     public Map<String, String> properties;
-    public List<FixSuggestionInfo> fixSuggestions;
   }
 
+  @CanIgnoreReturnValue
   public ReviewInput message(String msg) {
     message = msg != null && !msg.isEmpty() ? msg : null;
     return this;
   }
 
+  @CanIgnoreReturnValue
+  public ReviewInput patchSetLevelComment(String message) {
+    Objects.requireNonNull(message);
+    CommentInput comment = new CommentInput();
+    comment.message = message;
+    // TODO(davido): Because of cyclic dependency, we cannot use here Patch.PATCHSET_LEVEL constant
+    comments = Collections.singletonMap("/PATCHSET_LEVEL", Collections.singletonList(comment));
+    return this;
+  }
+
+  @CanIgnoreReturnValue
   public ReviewInput label(String name, short value) {
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException();
@@ -126,6 +153,7 @@ public class ReviewInput {
     return this;
   }
 
+  @CanIgnoreReturnValue
   public ReviewInput label(String name, int value) {
     if (value < Short.MIN_VALUE || value > Short.MAX_VALUE) {
       throw new IllegalArgumentException();
@@ -133,16 +161,24 @@ public class ReviewInput {
     return label(name, (short) value);
   }
 
+  @CanIgnoreReturnValue
   public ReviewInput label(String name) {
     return label(name, (short) 1);
   }
 
+  @CanIgnoreReturnValue
   public ReviewInput reviewer(String reviewer) {
-    return reviewer(reviewer, REVIEWER, false);
+    return reviewer(reviewer, REVIEWER, /* confirmed= */ false);
   }
 
+  @CanIgnoreReturnValue
+  public ReviewInput cc(String cc) {
+    return reviewer(cc, CC, /* confirmed= */ false);
+  }
+
+  @CanIgnoreReturnValue
   public ReviewInput reviewer(String reviewer, ReviewerState state, boolean confirmed) {
-    AddReviewerInput input = new AddReviewerInput();
+    ReviewerInput input = new ReviewerInput();
     input.reviewer = reviewer;
     input.state = state;
     input.confirmed = confirmed;
@@ -153,6 +189,7 @@ public class ReviewInput {
     return this;
   }
 
+  @CanIgnoreReturnValue
   public ReviewInput addUserToAttentionSet(String user, String reason) {
     AttentionSetInput input = new AttentionSetInput();
     input.user = user;
@@ -164,6 +201,7 @@ public class ReviewInput {
     return this;
   }
 
+  @CanIgnoreReturnValue
   public ReviewInput removeUserFromAttentionSet(String user, String reason) {
     AttentionSetInput input = new AttentionSetInput();
     input.user = user;
@@ -175,17 +213,20 @@ public class ReviewInput {
     return this;
   }
 
+  @CanIgnoreReturnValue
   public ReviewInput blockAutomaticAttentionSetRules() {
     ignoreAutomaticAttentionSetRules = true;
     return this;
   }
 
+  @CanIgnoreReturnValue
   public ReviewInput setWorkInProgress(boolean workInProgress) {
     this.workInProgress = workInProgress;
     ready = !workInProgress;
     return this;
   }
 
+  @CanIgnoreReturnValue
   public ReviewInput setReady(boolean ready) {
     this.ready = ready;
     workInProgress = !ready;

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ReviewInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ReviewInput.java
@@ -112,9 +112,7 @@ public class ReviewInput {
     PUBLISH_ALL_REVISIONS
   }
 
-  public static class CommentInput extends Comment {
-    public Boolean unresolved;
-  }
+  public static class CommentInput extends Comment {}
 
   /** @deprecated removed upstream; the underlying REST resource may still exist. */
   @Deprecated

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ReviewResult.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ReviewResult.java
@@ -15,6 +15,7 @@
 package com.google.gerrit.extensions.api.changes;
 
 import com.google.gerrit.common.Nullable;
+import com.google.gerrit.extensions.common.ChangeInfo;
 import java.util.Map;
 
 /** Result object representing the outcome of a review request. */
@@ -29,7 +30,7 @@ public class ReviewResult {
    * Map of account or group identifier to outcome of adding as a reviewer. Null if no reviewer
    * additions were requested.
    */
-  @Nullable public Map<String, AddReviewerResult> reviewers;
+  @Nullable public Map<String, ReviewerResult> reviewers;
 
   /**
    * Boolean indicating whether the change was moved out of WIP by this review. Either true or null.
@@ -38,4 +39,7 @@ public class ReviewResult {
 
   /** Error message for non-200 responses. */
   @Nullable public String error;
+
+  /** Change after applying the update. */
+  @Nullable public ChangeInfo changeInfo;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ReviewerInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ReviewerInput.java
@@ -1,0 +1,38 @@
+// Copyright (C) 2013 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+import static com.google.gerrit.extensions.client.ReviewerState.REVIEWER;
+
+import com.google.gerrit.extensions.client.ReviewerState;
+import com.google.gerrit.extensions.restapi.DefaultInput;
+import java.util.Map;
+
+public class ReviewerInput {
+  @DefaultInput public String reviewer;
+  public Boolean confirmed;
+  public ReviewerState state;
+  public NotifyHandling notify;
+  public Map<RecipientType, NotifyInfo> notifyDetails;
+  public String onBehalfOf;
+
+  public boolean confirmed() {
+    return (confirmed != null) ? confirmed : false;
+  }
+
+  public ReviewerState state() {
+    return (state != null) ? state : REVIEWER;
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/ReviewerResult.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/ReviewerResult.java
@@ -1,0 +1,79 @@
+// Copyright (C) 2016 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.changes;
+
+import com.google.gerrit.common.Nullable;
+import com.google.gerrit.extensions.common.AccountInfo;
+import java.util.List;
+
+/** Result object representing the outcome of a request to add/remove a reviewer. */
+public class ReviewerResult {
+  /** The identifier of an account or group that was to be added/removed as a reviewer. */
+  public String input;
+
+  /** If non-null, a string describing why the reviewer could not be added/removed. */
+  @Nullable public String error;
+
+  /**
+   * Non-null and true if the reviewer cannot be added without explicit confirmation. This may be
+   * the case for groups of a certain size. For removals, it's always false.
+   */
+  @Nullable public Boolean confirm;
+
+  /**
+   * List of individual reviewers added to the change. The size of this list may be greater than one
+   * (e.g. when a group is added). Null if no reviewers were added.
+   */
+  @Nullable public List<ReviewerInfo> reviewers;
+
+  /**
+   * List of new accounts CCed on the change. The size of this list may be greater than one (e.g.
+   * when a group is CCed). Null if no accounts were CCed.
+   */
+  @Nullable public List<AccountInfo> ccs;
+
+  /** An account removed from the change. Null if no accounts were removed. */
+  @Nullable public AccountInfo removed;
+
+  /**
+   * Constructs a partially initialized result for the given reviewer.
+   *
+   * @param input String identifier of an account or group, from user request
+   */
+  public ReviewerResult(String input) {
+    this.input = input;
+  }
+
+  /**
+   * Constructs an error result for the given account.
+   *
+   * @param reviewer String identifier of an account or group
+   * @param error Error message
+   */
+  public ReviewerResult(String reviewer, String error) {
+    this(reviewer);
+    this.error = error;
+  }
+
+  /**
+   * Constructs a needs-confirmation result for the given account.
+   *
+   * @param confirm Whether confirmation is needed.
+   */
+  public ReviewerResult(String reviewer, boolean confirm) {
+    this(reviewer);
+    this.confirm = confirm;
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/api/changes/RevisionApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/RevisionApi.java
@@ -15,10 +15,12 @@
 package com.google.gerrit.extensions.api.changes;
 
 import com.google.common.collect.ListMultimap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.common.Nullable;
 import com.google.gerrit.extensions.client.ArchiveFormat;
 import com.google.gerrit.extensions.client.SubmitType;
 import com.google.gerrit.extensions.common.ActionInfo;
+import com.google.gerrit.extensions.common.ApplyProvidedFixInput;
 import com.google.gerrit.extensions.common.ApprovalInfo;
 import com.google.gerrit.extensions.common.ChangeInfo;
 import com.google.gerrit.extensions.common.CommentInfo;
@@ -27,52 +29,52 @@ import com.google.gerrit.extensions.common.DiffInfo;
 import com.google.gerrit.extensions.common.EditInfo;
 import com.google.gerrit.extensions.common.FileInfo;
 import com.google.gerrit.extensions.common.MergeableInfo;
+import com.google.gerrit.extensions.common.RevisionInfo;
 import com.google.gerrit.extensions.common.RobotCommentInfo;
 import com.google.gerrit.extensions.common.TestSubmitRuleInfo;
 import com.google.gerrit.extensions.common.TestSubmitRuleInput;
 import com.google.gerrit.extensions.restapi.BinaryResult;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public interface RevisionApi {
-  @Deprecated
-  void delete() throws RestApiException;
+  RevisionInfo get() throws RestApiException;
 
   String description() throws RestApiException;
 
   void description(String description) throws RestApiException;
 
+  @CanIgnoreReturnValue
   ReviewResult review(ReviewInput in) throws RestApiException;
 
-  default void submit() throws RestApiException {
+  @CanIgnoreReturnValue
+  default ChangeInfo submit() throws RestApiException {
     SubmitInput in = new SubmitInput();
-    submit(in);
+    return submit(in);
   }
 
-  void submit(SubmitInput in) throws RestApiException;
+  @CanIgnoreReturnValue
+  ChangeInfo submit(SubmitInput in) throws RestApiException;
 
-  default BinaryResult submitPreview() throws RestApiException {
-    return submitPreview("zip");
-  }
-
-  BinaryResult submitPreview(String format) throws RestApiException;
-
-  @Deprecated
-  void publish() throws RestApiException;
-
+  @CanIgnoreReturnValue
   ChangeApi cherryPick(CherryPickInput in) throws RestApiException;
 
   ChangeInfo cherryPickAsInfo(CherryPickInput in) throws RestApiException;
 
+  @CanIgnoreReturnValue
   default ChangeApi rebase() throws RestApiException {
     RebaseInput in = new RebaseInput();
     return rebase(in);
   }
 
+  @CanIgnoreReturnValue
   ChangeApi rebase(RebaseInput in) throws RestApiException;
+
+  ChangeInfo rebaseAsInfo(RebaseInput in) throws RestApiException;
 
   boolean canRebase() throws RestApiException;
 
@@ -102,15 +104,15 @@ public interface RevisionApi {
 
   Map<String, List<CommentInfo>> comments() throws RestApiException;
 
-  Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException;
-
   Map<String, List<CommentInfo>> drafts() throws RestApiException;
 
   List<CommentInfo> commentsAsList() throws RestApiException;
 
   List<CommentInfo> draftsAsList() throws RestApiException;
 
-  List<RobotCommentInfo> robotCommentsAsList() throws RestApiException;
+  Map<String, List<CommentInfo>> portedComments() throws RestApiException;
+
+  Map<String, List<CommentInfo>> portedDrafts() throws RestApiException;
 
   /**
    * Applies the indicated fix by creating a new change edit or integrating the fix with the
@@ -121,19 +123,30 @@ public interface RevisionApi {
    * @param fixId the ID of the fix which should be applied
    * @throws RestApiException if the fix couldn't be applied
    */
+  @CanIgnoreReturnValue
   EditInfo applyFix(String fixId) throws RestApiException;
+
+  /**
+   * Applies fix similar to {@code applyFix} method. Instead of using a fix stored in the server,
+   * this applies the fix provided in {@code ApplyProvidedFixInput}
+   *
+   * @param applyProvidedFixInput The fix(es) to apply to a new change edit.
+   * @throws RestApiException if the fix couldn't be applied.
+   */
+  @CanIgnoreReturnValue
+  EditInfo applyFix(ApplyProvidedFixInput applyProvidedFixInput) throws RestApiException;
 
   Map<String, DiffInfo> getFixPreview(String fixId) throws RestApiException;
 
+  Map<String, DiffInfo> getFixPreview(ApplyProvidedFixInput applyProvidedFixInput)
+      throws RestApiException;
+
+  @CanIgnoreReturnValue
   DraftApi createDraft(DraftInput in) throws RestApiException;
 
   DraftApi draft(String id) throws RestApiException;
 
   CommentApi comment(String id) throws RestApiException;
-
-  RobotCommentApi robotComment(String id) throws RestApiException;
-
-  String etag() throws RestApiException;
 
   /** Returns patch of revision. */
   BinaryResult patch() throws RestApiException;
@@ -152,6 +165,8 @@ public interface RevisionApi {
 
   RelatedChangesInfo related() throws RestApiException;
 
+  RelatedChangesInfo related(EnumSet<GetRelatedOption> listOptions) throws RestApiException;
+
   /** Returns votes on the revision. */
   ListMultimap<String, ApprovalInfo> votes() throws RestApiException;
 
@@ -160,7 +175,6 @@ public interface RevisionApi {
    *
    * @param format the format of the archive
    * @return the archive as {@link BinaryResult}
-   * @throws RestApiException
    */
   BinaryResult getArchive(ArchiveFormat format) throws RestApiException;
 
@@ -189,14 +203,53 @@ public interface RevisionApi {
     }
   }
 
+  // The methods below were removed from this interface upstream. They are kept here, deprecated,
+  // so that source and binary compatibility is preserved for existing implementers/callers of this
+  // interface.
+
+  /** @deprecated removed upstream along with the "draft patch set" feature it published. */
+  @Deprecated
+  void publish() throws RestApiException;
+
+  /** @deprecated removed upstream along with the "draft patch set" feature it deleted. */
+  @Deprecated
+  void delete() throws RestApiException;
+
+  /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
+  @Deprecated
+  Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException;
+
+  /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
+  @Deprecated
+  RobotCommentApi robotComment(String id) throws RestApiException;
+
+  /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
+  @Deprecated
+  default BinaryResult submitPreview() throws RestApiException {
+    return submitPreview(null);
+  }
+
+  /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
+  @Deprecated
+  BinaryResult submitPreview(String format) throws RestApiException;
+
   /**
    * A default implementation which allows source compatibility when adding new methods to the
    * interface.
    */
   class NotImplemented implements RevisionApi {
-    @Deprecated
     @Override
-    public void delete() throws RestApiException {
+    public RevisionInfo get() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public String description() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void description(String description) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -206,13 +259,7 @@ public interface RevisionApi {
     }
 
     @Override
-    public void submit(SubmitInput in) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Deprecated
-    @Override
-    public void publish() throws RestApiException {
+    public ChangeInfo submit(SubmitInput in) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -228,6 +275,11 @@ public interface RevisionApi {
 
     @Override
     public ChangeApi rebase(RebaseInput in) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public ChangeInfo rebaseAsInfo(RebaseInput in) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -252,17 +304,7 @@ public interface RevisionApi {
     }
 
     @Override
-    public MergeableInfo mergeable() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public MergeableInfo mergeableOtherBranches() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public Map<String, FileInfo> files(String base) throws RestApiException {
+    public Map<String, FileInfo> files(@Nullable String base) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -287,12 +329,22 @@ public interface RevisionApi {
     }
 
     @Override
+    public MergeableInfo mergeable() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public MergeableInfo mergeableOtherBranches() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
     public Map<String, List<CommentInfo>> comments() throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    public Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException {
+    public Map<String, List<CommentInfo>> drafts() throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -307,7 +359,12 @@ public interface RevisionApi {
     }
 
     @Override
-    public List<RobotCommentInfo> robotCommentsAsList() throws RestApiException {
+    public Map<String, List<CommentInfo>> portedComments() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map<String, List<CommentInfo>> portedDrafts() throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -317,12 +374,17 @@ public interface RevisionApi {
     }
 
     @Override
+    public EditInfo applyFix(ApplyProvidedFixInput applyProvidedFixInput) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
     public Map<String, DiffInfo> getFixPreview(String fixId) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    public Map<String, List<CommentInfo>> drafts() throws RestApiException {
+    public Map<String, DiffInfo> getFixPreview(ApplyProvidedFixInput applyProvidedFixInput) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -338,11 +400,6 @@ public interface RevisionApi {
 
     @Override
     public CommentApi comment(String id) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public RobotCommentApi robotComment(String id) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -367,11 +424,6 @@ public interface RevisionApi {
     }
 
     @Override
-    public BinaryResult submitPreview(String format) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
     public SubmitType testSubmitType(TestSubmitRuleInput in) throws RestApiException {
       throw new NotImplementedException();
     }
@@ -392,27 +444,42 @@ public interface RevisionApi {
     }
 
     @Override
+    public RelatedChangesInfo related(EnumSet<GetRelatedOption> listOptions) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
     public ListMultimap<String, ApprovalInfo> votes() throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    public void description(String description) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public String description() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public String etag() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
     public BinaryResult getArchive(ArchiveFormat format) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void publish() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void delete() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map<String, List<RobotCommentInfo>> robotComments() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public RobotCommentApi robotComment(String id) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public BinaryResult submitPreview(String format) throws RestApiException {
       throw new NotImplementedException();
     }
   }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/RevisionApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/RevisionApi.java
@@ -233,6 +233,14 @@ public interface RevisionApi {
   @Deprecated
   BinaryResult submitPreview(String format) throws RestApiException;
 
+  /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
+  @Deprecated
+  List<RobotCommentInfo> robotCommentsAsList() throws RestApiException;
+
+  /** @deprecated removed upstream from this interface; the underlying REST resource may still exist. */
+  @Deprecated
+  String etag() throws RestApiException;
+
   /**
    * A default implementation which allows source compatibility when adding new methods to the
    * interface.
@@ -480,6 +488,16 @@ public interface RevisionApi {
 
     @Override
     public BinaryResult submitPreview(String format) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public List<RobotCommentInfo> robotCommentsAsList() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public String etag() throws RestApiException {
       throw new NotImplementedException();
     }
   }

--- a/src/main/java/com/google/gerrit/extensions/api/changes/SubmittedTogetherOption.java
+++ b/src/main/java/com/google/gerrit/extensions/api/changes/SubmittedTogetherOption.java
@@ -16,5 +16,6 @@ package com.google.gerrit.extensions.api.changes;
 
 /** Output options available for submitted_together requests. */
 public enum SubmittedTogetherOption {
-  NON_VISIBLE_CHANGES;
+  NON_VISIBLE_CHANGES,
+  TOPIC_CLOSURE;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/config/AccessCheckInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/api/config/AccessCheckInfo.java
@@ -14,10 +14,15 @@
 
 package com.google.gerrit.extensions.api.config;
 
+import java.util.List;
+
 public class AccessCheckInfo {
   public String message;
   // HTTP status code
   public int status;
+
+  /** Debug logs that may help to understand why a permission is denied or allowed. */
+  public List<String> debugLogs;
 
   // for future extension, we may add inputs / results for bulk checks.
 }

--- a/src/main/java/com/google/gerrit/extensions/api/config/CachesApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/config/CachesApi.java
@@ -1,0 +1,41 @@
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.config;
+
+import com.google.gerrit.extensions.common.CacheInfo;
+import com.google.gerrit.extensions.restapi.NotImplementedException;
+import com.google.gerrit.extensions.restapi.RestApiException;
+
+public interface CachesApi {
+  CacheInfo get() throws RestApiException;
+
+  void flush() throws RestApiException;
+
+  /**
+   * A default implementation which allows source compatibility when adding new methods to the
+   * interface.
+   */
+  class NotImplemented implements CachesApi {
+    @Override
+    public CacheInfo get() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void flush() throws RestApiException {
+      throw new NotImplementedException();
+    }
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/api/config/Config.java
+++ b/src/main/java/com/google/gerrit/extensions/api/config/Config.java
@@ -17,7 +17,7 @@ package com.google.gerrit.extensions.api.config;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 
 public interface Config {
-  /** @return An API for getting server related configurations. */
+  /** Returns an API for getting server related configurations. */
   Server server();
 
   /**

--- a/src/main/java/com/google/gerrit/extensions/api/config/ConsistencyCheckInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/api/config/ConsistencyCheckInfo.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.extensions.api.config;
 
+import com.google.errorprone.annotations.FormatMethod;
 import java.util.List;
 import java.util.Objects;
 
@@ -48,6 +49,7 @@ public class ConsistencyCheckInfo {
 
   public static class ConsistencyProblemInfo {
     public enum Status {
+      FATAL,
       ERROR,
       WARNING,
     }
@@ -79,10 +81,12 @@ public class ConsistencyCheckInfo {
       return status.name() + ": " + message;
     }
 
+    @FormatMethod
     public static ConsistencyProblemInfo warning(String fmt, Object... args) {
       return new ConsistencyProblemInfo(Status.WARNING, String.format(fmt, args));
     }
 
+    @FormatMethod
     public static ConsistencyProblemInfo error(String fmt, Object... args) {
       return new ConsistencyProblemInfo(Status.ERROR, String.format(fmt, args));
     }

--- a/src/main/java/com/google/gerrit/extensions/api/config/ExperimentApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/config/ExperimentApi.java
@@ -1,0 +1,34 @@
+// Copyright (C) 20124 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.config;
+
+import com.google.gerrit.extensions.common.ExperimentInfo;
+import com.google.gerrit.extensions.restapi.NotImplementedException;
+import com.google.gerrit.extensions.restapi.RestApiException;
+
+public interface ExperimentApi {
+  ExperimentInfo get() throws RestApiException;
+
+  /**
+   * A default implementation which allows source compatibility when adding new methods to the
+   * interface.
+   */
+  class NotImplemented implements ExperimentApi {
+    @Override
+    public ExperimentInfo get() throws RestApiException {
+      throw new NotImplementedException();
+    }
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/api/config/Server.java
+++ b/src/main/java/com/google/gerrit/extensions/api/config/Server.java
@@ -14,36 +14,82 @@
 
 package com.google.gerrit.extensions.api.config;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.extensions.client.DiffPreferencesInfo;
 import com.google.gerrit.extensions.client.EditPreferencesInfo;
 import com.google.gerrit.extensions.client.GeneralPreferencesInfo;
+import com.google.gerrit.extensions.common.CacheInfo;
+import com.google.gerrit.extensions.common.ExperimentInfo;
+import com.google.gerrit.extensions.common.LabelDefinitionInfo;
 import com.google.gerrit.extensions.common.ServerInfo;
+import com.google.gerrit.extensions.common.SubmitRequirementInfo;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
 //import com.google.gerrit.extensions.webui.TopMenu;
 import java.util.List;
+import java.util.Map;
 
 public interface Server {
-  /** @return Version of server. */
+  /** Returns version of server. */
   String getVersion() throws RestApiException;
 
   ServerInfo getInfo() throws RestApiException;
 
   GeneralPreferencesInfo getDefaultPreferences() throws RestApiException;
 
+  @CanIgnoreReturnValue
   GeneralPreferencesInfo setDefaultPreferences(GeneralPreferencesInfo in) throws RestApiException;
 
   DiffPreferencesInfo getDefaultDiffPreferences() throws RestApiException;
 
+  @CanIgnoreReturnValue
   DiffPreferencesInfo setDefaultDiffPreferences(DiffPreferencesInfo in) throws RestApiException;
 
   EditPreferencesInfo getDefaultEditPreferences() throws RestApiException;
 
+  @CanIgnoreReturnValue
   EditPreferencesInfo setDefaultEditPreferences(EditPreferencesInfo in) throws RestApiException;
 
   ConsistencyCheckInfo checkConsistency(ConsistencyCheckInput in) throws RestApiException;
 
 //  List<TopMenu.MenuEntry> topMenus() throws RestApiException;
+
+  ExperimentApi experiment(String name) throws RestApiException;
+
+  ListExperimentsRequest listExperiments() throws RestApiException;
+
+  ListGlobalLabelsRequest listGlobalLabels() throws RestApiException;
+
+  ListGlobalSubmitRequirementsRequest listGlobalSubmitRequirements() throws RestApiException;
+
+  CachesApi caches(String name) throws RestApiException;
+
+  Map<String, CacheInfo> listCaches() throws RestApiException;
+
+  abstract class ListExperimentsRequest {
+    private boolean enabledOnly;
+
+    public abstract ImmutableMap<String, ExperimentInfo> get() throws RestApiException;
+
+    public ListExperimentsRequest enabledOnly() {
+      enabledOnly = true;
+      return this;
+    }
+
+    public boolean getEnabledOnly() {
+      return enabledOnly;
+    }
+  }
+
+  abstract class ListGlobalLabelsRequest {
+    public abstract ImmutableList<LabelDefinitionInfo> get() throws RestApiException;
+  }
+
+  abstract class ListGlobalSubmitRequirementsRequest {
+    public abstract ImmutableList<SubmitRequirementInfo> get() throws RestApiException;
+  }
 
   /**
    * A default implementation which allows source compatibility when adding new methods to the
@@ -102,5 +148,36 @@ public interface Server {
 //    public List<TopMenu.MenuEntry> topMenus() throws RestApiException {
 //      throw new NotImplementedException();
 //    }
+
+    @Override
+    public ExperimentApi experiment(String name) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public ListExperimentsRequest listExperiments() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public ListGlobalLabelsRequest listGlobalLabels() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public ListGlobalSubmitRequirementsRequest listGlobalSubmitRequirements()
+        throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public CachesApi caches(String name) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map<String, CacheInfo> listCaches() throws RestApiException {
+      throw new NotImplementedException();
+    }
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/api/groups/GroupApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/groups/GroupApi.java
@@ -24,53 +24,52 @@ import java.util.Arrays;
 import java.util.List;
 
 public interface GroupApi {
-  /** @return group info with no {@code ListGroupsOption}s set. */
+  /** Returns group info with no {@code ListGroupsOption}s set. */
   GroupInfo get() throws RestApiException;
 
-  /** @return group info with all {@code ListGroupsOption}s set. */
+  /** Returns group info with all {@code ListGroupsOption}s set. */
   GroupInfo detail() throws RestApiException;
 
-  /** @return group name. */
+  /** Returns group name. */
   String name() throws RestApiException;
 
   /**
    * Set group name.
    *
    * @param name new name.
-   * @throws RestApiException
    */
   void name(String name) throws RestApiException;
 
-  /** @return owning group info. */
+  /** Delete group. */
+  void delete() throws RestApiException;
+
+  /** Returns owning group info. */
   GroupInfo owner() throws RestApiException;
 
   /**
    * Set group owner.
    *
    * @param owner identifier of new group owner.
-   * @throws RestApiException
    */
   void owner(String owner) throws RestApiException;
 
-  /** @return group description. */
+  /** Returns group description. */
   String description() throws RestApiException;
 
   /**
    * Set group decsription.
    *
    * @param description new description.
-   * @throws RestApiException
    */
   void description(String description) throws RestApiException;
 
-  /** @return group options. */
+  /** Returns group options. */
   GroupOptionsInfo options() throws RestApiException;
 
   /**
    * Set group options.
    *
    * @param options new options.
-   * @throws RestApiException
    */
   void options(GroupOptionsInfo options) throws RestApiException;
 
@@ -78,7 +77,6 @@ public interface GroupApi {
    * List group members, non-recursively.
    *
    * @return group members.
-   * @throws RestApiException
    */
   List<AccountInfo> members() throws RestApiException;
 
@@ -87,7 +85,6 @@ public interface GroupApi {
    *
    * @param recursive whether to recursively included groups.
    * @return group members.
-   * @throws RestApiException
    */
   List<AccountInfo> members(boolean recursive) throws RestApiException;
 
@@ -96,7 +93,6 @@ public interface GroupApi {
    *
    * @param members list of member identifiers, in any format accepted by {@link
    *     com.google.gerrit.extensions.api.accounts.Accounts#id(String)}
-   * @throws RestApiException
    */
   void addMembers(List<String> members) throws RestApiException;
 
@@ -105,7 +101,6 @@ public interface GroupApi {
    *
    * @param members list of member identifiers, in any format accepted by {@link
    *     com.google.gerrit.extensions.api.accounts.Accounts#id(String)}
-   * @throws RestApiException
    */
   default void addMembers(String... members) throws RestApiException {
     addMembers(Arrays.asList(members));
@@ -116,7 +111,6 @@ public interface GroupApi {
    *
    * @param members list of member identifiers, in any format accepted by {@link
    *     com.google.gerrit.extensions.api.accounts.Accounts#id(String)}
-   * @throws RestApiException
    */
   void removeMembers(List<String> members) throws RestApiException;
 
@@ -125,7 +119,6 @@ public interface GroupApi {
    *
    * @param members list of member identifiers, in any format accepted by {@link
    *     com.google.gerrit.extensions.api.accounts.Accounts#id(String)}
-   * @throws RestApiException
    */
   default void removeMembers(String... members) throws RestApiException {
     removeMembers(Arrays.asList(members));
@@ -135,7 +128,6 @@ public interface GroupApi {
    * Lists the subgroups of this group.
    *
    * @return the found subgroups
-   * @throws RestApiException
    */
   List<GroupInfo> includedGroups() throws RestApiException;
 
@@ -143,7 +135,6 @@ public interface GroupApi {
    * Adds subgroups to this group.
    *
    * @param groups list of group identifiers, in any format accepted by {@link Groups#id(String)}
-   * @throws RestApiException
    */
   void addGroups(List<String> groups) throws RestApiException;
 
@@ -151,7 +142,6 @@ public interface GroupApi {
    * Adds subgroups to this group.
    *
    * @param groups list of group identifiers, in any format accepted by {@link Groups#id(String)}
-   * @throws RestApiException
    */
   default void addGroups(String... groups) throws RestApiException {
     addGroups(Arrays.asList(groups));
@@ -161,7 +151,6 @@ public interface GroupApi {
    * Removes subgroups from this group.
    *
    * @param groups list of group identifiers, in any format accepted by {@link Groups#id(String)}
-   * @throws RestApiException
    */
   void removeGroups(List<String> groups) throws RestApiException;
 
@@ -169,7 +158,6 @@ public interface GroupApi {
    * Removes subgroups from this group.
    *
    * @param groups list of group identifiers, in any format accepted by {@link Groups#id(String)}
-   * @throws RestApiException
    */
   default void removeGroups(String... groups) throws RestApiException {
     removeGroups(Arrays.asList(groups));
@@ -179,7 +167,6 @@ public interface GroupApi {
    * Returns the audit log of the group.
    *
    * @return list of audit events of the group.
-   * @throws RestApiException
    */
   List<? extends GroupAuditEventInfo> auditLog() throws RestApiException;
 
@@ -187,8 +174,6 @@ public interface GroupApi {
    * Reindexes the group.
    *
    * <p>Only supported for internal groups.
-   *
-   * @throws RestApiException
    */
   void index() throws RestApiException;
 
@@ -214,6 +199,11 @@ public interface GroupApi {
 
     @Override
     public void name(String name) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void delete() throws RestApiException {
       throw new NotImplementedException();
     }
 

--- a/src/main/java/com/google/gerrit/extensions/api/groups/Groups.java
+++ b/src/main/java/com/google/gerrit/extensions/api/groups/Groups.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.extensions.api.groups;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.extensions.client.ListGroupsOption;
 import com.google.gerrit.extensions.common.GroupInfo;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
@@ -42,12 +43,14 @@ public interface Groups {
   GroupApi id(String id) throws RestApiException;
 
   /** Create a new group with the given name and default options. */
+  @CanIgnoreReturnValue
   GroupApi create(String name) throws RestApiException;
 
   /** Create a new group. */
+  @CanIgnoreReturnValue
   GroupApi create(GroupInput input) throws RestApiException;
 
-  /** @return new request for listing groups. */
+  /** Returns new request for listing groups. */
   ListRequest list();
 
   /**

--- a/src/main/java/com/google/gerrit/extensions/api/plugins/Plugins.java
+++ b/src/main/java/com/google/gerrit/extensions/api/plugins/Plugins.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.extensions.api.plugins;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.extensions.common.PluginInfo;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
@@ -29,9 +30,11 @@ public interface Plugins {
   PluginApi name(String name) throws RestApiException;
 
   @Deprecated
+  @CanIgnoreReturnValue
   PluginApi install(String name, com.google.gerrit.extensions.common.InstallPluginInput input)
       throws RestApiException;
 
+  @CanIgnoreReturnValue
   PluginApi install(String name, InstallPluginInput input) throws RestApiException;
 
   abstract class ListRequest {
@@ -114,25 +117,22 @@ public interface Plugins {
    */
   class NotImplemented implements Plugins {
     @Override
-    public ListRequest list() {
+    public ListRequest list() throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    public PluginApi name(String name) {
+    public PluginApi name(String name) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    @Deprecated
-    public PluginApi install(
-        String name, com.google.gerrit.extensions.common.InstallPluginInput input)
-        throws RestApiException {
+    public PluginApi install(String name, com.google.gerrit.extensions.common.InstallPluginInput input) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    public PluginApi install(String name, InstallPluginInput input) {
+    public PluginApi install(String name, InstallPluginInput input) throws RestApiException {
       throw new NotImplementedException();
     }
   }

--- a/src/main/java/com/google/gerrit/extensions/api/projects/BranchApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/BranchApi.java
@@ -14,12 +14,17 @@
 
 package com.google.gerrit.extensions.api.projects;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.gerrit.extensions.api.changes.ChangeApi.SuggestedReviewersRequest;
+import com.google.gerrit.extensions.common.CommitInfo;
+import com.google.gerrit.extensions.common.ValidationOptionInfos;
 import com.google.gerrit.extensions.restapi.BinaryResult;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
 import java.util.List;
 
 public interface BranchApi {
+  @CanIgnoreReturnValue
   BranchApi create(BranchInput in) throws RestApiException;
 
   BranchInfo get() throws RestApiException;
@@ -29,7 +34,25 @@ public interface BranchApi {
   /** Returns the content of a file from the HEAD revision. */
   BinaryResult file(String path) throws RestApiException;
 
+  /**
+   * Commits a set of file operations (write/create, delete, rename) to the branch as one commit and
+   * returns the new commit.
+   */
+  CommitInfo createCommit(CreateCommitInput input) throws RestApiException;
+
   List<ReflogEntryInfo> reflog() throws RestApiException;
+
+  SuggestedReviewersRequest suggestReviewers() throws RestApiException;
+
+  ValidationOptionInfos getValidationOptions() throws RestApiException;
+
+  default SuggestedReviewersRequest suggestReviewers(String query) throws RestApiException {
+    return suggestReviewers().withQuery(query);
+  }
+
+  default SuggestedReviewersRequest suggestCcs(String query) throws RestApiException {
+    return suggestReviewers().forCc().withQuery(query);
+  }
 
   /**
    * A default implementation which allows source compatibility when adding new methods to the
@@ -57,7 +80,22 @@ public interface BranchApi {
     }
 
     @Override
+    public CommitInfo createCommit(CreateCommitInput input) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
     public List<ReflogEntryInfo> reflog() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public SuggestedReviewersRequest suggestReviewers() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public ValidationOptionInfos getValidationOptions() throws RestApiException {
       throw new NotImplementedException();
     }
   }

--- a/src/main/java/com/google/gerrit/extensions/api/projects/BranchInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/BranchInput.java
@@ -15,8 +15,46 @@
 package com.google.gerrit.extensions.api.projects;
 
 import com.google.gerrit.extensions.restapi.DefaultInput;
+import java.util.Map;
 
+/**
+ * Input for creating a new branch.
+ * https://gerrit-review.googlesource.com/Documentation/rest-api-projects.html#branch-input
+ *
+ * <p>This class holds the data needed to create a new branch, such as the revision to base the
+ * branch on and whether to create an empty commit.
+ *
+ * <p>The following properties can be set:
+ *
+ * <ul>
+ *   <li>{@code revision}: The base revision of the new branch. If not set and create_empty_commit
+ *       is true the branch is created with an empty initial commit. If not set and
+ *       create_empty_commit is false or unset HEAD will be used as base revision.
+ *   <li>{@code createEmptyCommit}: Whether the branch should be created with an empty initial
+ *       commit. It is not possible to create a branch on a project with no commits. Cannot be used
+ *       in combination with setting a revision. Can be used to review the initial content of a
+ *       branch (create the branch with an empty initial commit, make a second commit with the
+ *       initial content, e.g. by merging in another branch, and push the commit for review)..
+ *   <li>{@code ref}: The name of the branch. The prefix refs/heads/ can be omitted. If set, must
+ *       match the branch ID in the URL.
+ *   <li>{@code sourceRef}: The full name of the source ref where {@code revision} can be found.
+ *       This ref should be visible to the caller. Used when {@code revision} is not a ref name in
+ *       order to check reachability from a specific ref. If not set, then all visible refs under
+ *       refs/heads/ and refs/tags/ are searched (see {@code CreateRefControl#checkCreateCommit} for
+ *       details).
+ *   <li>{@code validationOptions}: Map with key-value pairs that are forwarded as options to the
+ *       ref operation validation listeners (e.g. can be used to skip certain validations). Which
+ *       validation options are supported depends on the installed ref operation validation
+ *       listeners. Gerrit core doesn’t support any validation options, but ref operation validation
+ *       listeners that are implemented in plugins may. Please refer to the documentation of the
+ *       installed plugins to learn whether they support validation options. Unknown validation
+ *       options are silently ignored.
+ * </ul>
+ */
 public class BranchInput {
   @DefaultInput public String revision;
+  public boolean createEmptyCommit;
   public String ref;
+  public String sourceRef;
+  public Map<String, String> validationOptions;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/projects/CommentLinkInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/CommentLinkInfo.java
@@ -17,11 +17,17 @@ package com.google.gerrit.extensions.api.projects;
 import com.google.common.base.MoreObjects;
 import java.util.Objects;
 
+/** See {@link com.google.gerrit.entities.StoredCommentLinkInfo} for field documentation. */
 public class CommentLinkInfo {
   public String match;
   public String link;
-  public String html;
+  public String prefix;
+  public String suffix;
+  public String text;
   public Boolean enabled; // null means true
+
+  /** @deprecated removed upstream in favor of the structured {@link #prefix}/{@link #suffix}/{@link #text}. */
+  @Deprecated public String html;
 
   public transient String name;
 
@@ -34,7 +40,9 @@ public class CommentLinkInfo {
       CommentLinkInfo that = (CommentLinkInfo) o;
       return Objects.equals(this.match, that.match)
           && Objects.equals(this.link, that.link)
-          && Objects.equals(this.html, that.html)
+          && Objects.equals(this.prefix, that.prefix)
+          && Objects.equals(this.suffix, that.suffix)
+          && Objects.equals(this.text, that.text)
           && Objects.equals(this.enabled, that.enabled);
     }
     return false;
@@ -42,7 +50,7 @@ public class CommentLinkInfo {
 
   @Override
   public int hashCode() {
-    return Objects.hash(match, link, html, enabled);
+    return Objects.hash(match, link, prefix, suffix, text, enabled);
   }
 
   @Override
@@ -51,7 +59,9 @@ public class CommentLinkInfo {
         .add("name", name)
         .add("match", match)
         .add("link", link)
-        .add("html", html)
+        .add("prefix", prefix)
+        .add("suffix", suffix)
+        .add("text", text)
         .add("enabled", enabled)
         .toString();
   }

--- a/src/main/java/com/google/gerrit/extensions/api/projects/CommentLinkInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/CommentLinkInput.java
@@ -14,14 +14,27 @@
 
 package com.google.gerrit.extensions.api.projects;
 
-/*
+/**
  * Input for a commentlink configuration on a project.
+ *
+ * <p>See {@link com.google.gerrit.entities.StoredCommentLinkInfo} for additional details.
  */
 public class CommentLinkInput {
   /** A JavaScript regular expression to match positions to be replaced with a hyperlink. */
   public String match;
+
   /** The URL to direct the user to whenever the regular expression is matched. */
   public String link;
+
+  /** Text inserted before the link if the regular expression is matched. */
+  public String prefix;
+
+  /** Text inserted after the link if the regular expression is matched. */
+  public String suffix;
+
+  /** Text of the link. */
+  public String text;
+
   /** Whether the commentlink is enabled. */
   public Boolean enabled;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/projects/CommitApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/CommitApi.java
@@ -18,8 +18,10 @@ import com.google.gerrit.extensions.api.changes.ChangeApi;
 import com.google.gerrit.extensions.api.changes.CherryPickInput;
 import com.google.gerrit.extensions.api.changes.IncludedInInfo;
 import com.google.gerrit.extensions.common.CommitInfo;
+import com.google.gerrit.extensions.common.FileInfo;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
+import java.util.Map;
 
 public interface CommitApi {
   CommitInfo get() throws RestApiException;
@@ -28,7 +30,23 @@ public interface CommitApi {
 
   IncludedInInfo includedIn() throws RestApiException;
 
-  /** A default implementation for source compatibility when adding new methods to the interface. */
+  /** List files in a specific commit against the parent commit. */
+  Map<String, FileInfo> files(int parentNum) throws RestApiException;
+
+  /**
+   * Lists files that differ between this commit and a base commit.
+   *
+   * @param base the base commit SHA1 (40 characters)
+   * @param nameOnly whether to return only the list of files without diff info
+   * @return map of file paths to FileInfo
+   * @throws RestApiException if commits are not in ancestor/descendant relationship or not visible
+   */
+  Map<String, FileInfo> diffFiles(String base, boolean nameOnly) throws RestApiException;
+
+  /**
+   * A default implementation which allows source compatibility when adding new methods to the
+   * interface.
+   */
   class NotImplemented implements CommitApi {
     @Override
     public CommitInfo get() throws RestApiException {
@@ -42,6 +60,16 @@ public interface CommitApi {
 
     @Override
     public IncludedInInfo includedIn() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map<String, FileInfo> files(int parentNum) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map<String, FileInfo> diffFiles(String base, boolean nameOnly) throws RestApiException {
       throw new NotImplementedException();
     }
   }

--- a/src/main/java/com/google/gerrit/extensions/api/projects/ConfigInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/ConfigInfo.java
@@ -40,6 +40,7 @@ public class ConfigInfo {
   public InheritedBooleanInfo enableReviewerByEmail;
   public InheritedBooleanInfo matchAuthorToCommitterDate;
   public InheritedBooleanInfo rejectEmptyCommit;
+  public InheritedBooleanInfo skipAddingAuthorAndCommitterAsReviewers;
 
   public MaxObjectSizeLimitInfo maxObjectSizeLimit;
   @Deprecated // Equivalent to defaultSubmitType.value

--- a/src/main/java/com/google/gerrit/extensions/api/projects/ConfigInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/ConfigInput.java
@@ -34,9 +34,11 @@ public class ConfigInput {
   public InheritableBoolean enableReviewerByEmail;
   public InheritableBoolean matchAuthorToCommitterDate;
   public InheritableBoolean rejectEmptyCommit;
+  public InheritableBoolean skipAddingAuthorAndCommitterAsReviewers;
   public String maxObjectSizeLimit;
   public SubmitType submitType;
   public ProjectState state;
   public Map<String, Map<String, ConfigValue>> pluginConfigValues;
   public Map<String, CommentLinkInput> commentLinks;
+  public String commitMessage;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/projects/ConfigValue.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/ConfigValue.java
@@ -17,6 +17,13 @@ package com.google.gerrit.extensions.api.projects;
 import java.util.List;
 
 public class ConfigValue {
+
+  public ConfigValue() {}
+
+  public ConfigValue(String value) {
+    this.value = value;
+  }
+
   public String value;
   public List<String> values;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/projects/CreateCommitInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/CreateCommitInput.java
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.projects;
+
+import java.util.Map;
+
+/**
+ * Input for creating a commit that applies a set of file operations to a branch in a single call.
+ */
+public class CreateCommitInput {
+  /** Commit message. */
+  public String commitMessage;
+
+  /**
+   * Optional base commit (SHA-1).
+   *
+   * <p>This is the expected current commit of the target branch: the request is rejected if the
+   * branch no longer points at it (optimistic concurrency / lost-update protection). When unset,
+   * the current branch tip is used.
+   */
+  public String baseRevision;
+
+  /**
+   * File operations to apply, keyed by file path. Each entry either writes/creates content, deletes
+   * the file, or renames another file to this path. Applied together as one commit.
+   */
+  public Map<String, FileChange> files;
+
+  /**
+   * Validation options as key-value pairs that are forwarded as options to the ref-operation and
+   * commit validation listeners (e.g. to skip certain validations). Which options are supported
+   * depends on the installed validation listeners; Gerrit core supports none. Unknown options are
+   * silently ignored.
+   */
+  public Map<String, String> validationOptions;
+
+  /** A single file operation within a {@link CreateCommitInput}. */
+  public static class FileChange {
+    /**
+     * New file content, base64-encoded, for a write or create. For a {@code 120000} (symlink)
+     * entry, the decoded content is the symlink target path. Mutually exclusive with {@link
+     * #delete} and {@link #renameFrom}.
+     */
+    public String content;
+
+    /**
+     * File mode in octal format. Supported values are {@code 100644} (regular file), {@code 100755}
+     * (executable file) and {@code 120000} (symlink). If unset, new files are created as {@code
+     * 100644} and existing files keep their mode.
+     */
+    public Integer fileMode;
+
+    /**
+     * When {@code true}, deletes the file at this path. Mutually exclusive with the other fields.
+     */
+    public boolean delete;
+
+    /**
+     * Source path to rename from. The file at {@code renameFrom} is moved to this entry's path.
+     * Mutually exclusive with {@link #content} and {@link #delete}.
+     */
+    public String renameFrom;
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/api/projects/DeleteChangesInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/DeleteChangesInput.java
@@ -1,0 +1,21 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.projects;
+
+import java.util.List;
+
+public class DeleteChangesInput {
+  public List<String> changes;
+}

--- a/src/main/java/com/google/gerrit/extensions/api/projects/DeleteChangesResult.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/DeleteChangesResult.java
@@ -1,0 +1,21 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.projects;
+
+public enum DeleteChangesResult {
+  NOT_UNIQUE,
+  SUCCESS,
+  FAILURE
+}

--- a/src/main/java/com/google/gerrit/extensions/api/projects/LabelApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/LabelApi.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.extensions.api.projects;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.common.Nullable;
 import com.google.gerrit.extensions.common.LabelDefinitionInfo;
 import com.google.gerrit.extensions.common.LabelDefinitionInput;
@@ -21,10 +22,12 @@ import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
 
 public interface LabelApi {
+  @CanIgnoreReturnValue
   LabelApi create(LabelDefinitionInput input) throws RestApiException;
 
   LabelDefinitionInfo get() throws RestApiException;
 
+  @CanIgnoreReturnValue
   LabelDefinitionInfo update(LabelDefinitionInput input) throws RestApiException;
 
   default void delete() throws RestApiException {

--- a/src/main/java/com/google/gerrit/extensions/api/projects/ProjectApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/ProjectApi.java
@@ -14,17 +14,26 @@
 
 package com.google.gerrit.extensions.api.projects;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.extensions.api.access.ProjectAccessInfo;
 import com.google.gerrit.extensions.api.access.ProjectAccessInput;
 import com.google.gerrit.extensions.api.config.AccessCheckInfo;
 import com.google.gerrit.extensions.api.config.AccessCheckInput;
 import com.google.gerrit.extensions.common.BatchLabelInput;
+import com.google.gerrit.extensions.common.BatchSubmitRequirementInput;
 import com.google.gerrit.extensions.common.ChangeInfo;
+import com.google.gerrit.extensions.common.DiffInfo;
+import com.google.gerrit.extensions.common.FileInfo;
 import com.google.gerrit.extensions.common.LabelDefinitionInfo;
+import com.google.gerrit.extensions.common.ListTagSortOption;
 import com.google.gerrit.extensions.common.ProjectInfo;
+import com.google.gerrit.extensions.common.SubmitRequirementInfo;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public interface ProjectApi {
   ProjectApi create() throws RestApiException;
@@ -39,8 +48,10 @@ public interface ProjectApi {
 
   ProjectAccessInfo access() throws RestApiException;
 
+  @CanIgnoreReturnValue
   ProjectAccessInfo access(ProjectAccessInput p) throws RestApiException;
 
+  @CanIgnoreReturnValue
   ChangeInfo accessChange(ProjectAccessInput p) throws RestApiException;
 
   AccessCheckInfo checkAccess(AccessCheckInput in) throws RestApiException;
@@ -49,7 +60,37 @@ public interface ProjectApi {
 
   ConfigInfo config() throws RestApiException;
 
+  @CanIgnoreReturnValue
   ConfigInfo config(ConfigInput in) throws RestApiException;
+
+  @CanIgnoreReturnValue
+  ChangeInfo configReview(ConfigInput in) throws RestApiException;
+
+  Map<String, Set<String>> commitsIn(Collection<String> commits, Collection<String> refs)
+      throws RestApiException;
+
+  /**
+   * Lists files that differ between two commits.
+   *
+   * @param oldCommit the old commit SHA1 (40 characters)
+   * @param newCommit the new commit SHA1 (40 characters)
+   * @param nameOnly whether to return only the list of files without diff info
+   * @return map of file paths to FileInfo
+   * @throws RestApiException if commits are not in ancestor/descendant relationship or not visible
+   */
+  Map<String, FileInfo> diffFiles(String oldCommit, String newCommit, boolean nameOnly)
+      throws RestApiException;
+
+  /**
+   * Gets the diff for a specific file between two commits.
+   *
+   * @param oldCommit the old commit SHA1 (40 characters)
+   * @param newCommit the new commit SHA1 (40 characters)
+   * @param path the file path
+   * @return DiffInfo for the file
+   * @throws RestApiException if commits are not in ancestor/descendant relationship or not visible
+   */
+  DiffInfo diffFile(String oldCommit, String newCommit, String path) throws RestApiException;
 
   ListRefsRequest<BranchInfo> branches();
 
@@ -57,13 +98,19 @@ public interface ProjectApi {
 
   void deleteBranches(DeleteBranchesInput in) throws RestApiException;
 
+  Map<DeleteChangesResult, Collection<String>> deleteChanges(DeleteChangesInput in)
+      throws RestApiException;
+
   void deleteTags(DeleteTagsInput in) throws RestApiException;
 
   abstract class ListRefsRequest<T extends RefInfo> {
     protected int limit;
     protected int start;
+    protected boolean descendingOrder;
     protected String substring;
     protected String regex;
+    protected String nextPageToken;
+    protected ListTagSortOption sortBy = ListTagSortOption.REF;
 
     public abstract List<T> get() throws RestApiException;
 
@@ -74,6 +121,21 @@ public interface ProjectApi {
 
     public ListRefsRequest<T> withStart(int start) {
       this.start = start;
+      return this;
+    }
+
+    public ListRefsRequest<T> withDescendingOrder(boolean descendingOrder) {
+      this.descendingOrder = descendingOrder;
+      return this;
+    }
+
+    public ListRefsRequest<T> withSortBy(ListTagSortOption sortBy) {
+      this.sortBy = sortBy;
+      return this;
+    }
+
+    public ListRefsRequest<T> withNextPageToken(String token) {
+      this.nextPageToken = token;
       return this;
     }
 
@@ -93,6 +155,18 @@ public interface ProjectApi {
 
     public int getStart() {
       return start;
+    }
+
+    public boolean getDescendingOrder() {
+      return descendingOrder;
+    }
+
+    public ListTagSortOption getSortBy() {
+      return sortBy;
+    }
+
+    public String getNextPageToken() {
+      return nextPageToken;
     }
 
     public String getSubstring() {
@@ -211,15 +285,37 @@ public interface ProjectApi {
   abstract class ListLabelsRequest {
     protected boolean inherited;
 
+    protected String voteableOnRef;
+
     public abstract List<LabelDefinitionInfo> get() throws RestApiException;
 
     public ListLabelsRequest withInherited(boolean inherited) {
       this.inherited = inherited;
       return this;
     }
+
+    public ListLabelsRequest withVoteableOnRef(String voteableOnRef) {
+      this.voteableOnRef = voteableOnRef;
+      return this;
+    }
   }
 
   LabelApi label(String labelName) throws RestApiException;
+
+  ListSubmitRequirementsRequest submitRequirements() throws RestApiException;
+
+  abstract class ListSubmitRequirementsRequest {
+    protected boolean inherited;
+
+    public abstract List<SubmitRequirementInfo> get() throws RestApiException;
+
+    public ListSubmitRequirementsRequest withInherited(boolean inherited) {
+      this.inherited = inherited;
+      return this;
+    }
+  }
+
+  SubmitRequirementApi submitRequirement(String name) throws RestApiException;
 
   /**
    * Adds, updates and deletes label definitions in a batch.
@@ -227,6 +323,25 @@ public interface ProjectApi {
    * @param input input that describes additions, updates and deletions of label definitions
    */
   void labels(BatchLabelInput input) throws RestApiException;
+
+  /** Same as {@link #labels(BatchLabelInput)}, but creates a change with required updates. */
+  @CanIgnoreReturnValue
+  ChangeInfo labelsReview(BatchLabelInput input) throws RestApiException;
+
+  /**
+   * Adds, updates and deletes submit requirements definitions in a batch.
+   *
+   * @param input input that describes additions, updates and deletions of submit requirements
+   */
+  void submitRequirements(BatchSubmitRequirementInput input) throws RestApiException;
+
+  /**
+   * Creates a change with required submit requirements updates.
+   *
+   * <p>See {@link #submitRequirements(BatchSubmitRequirementInput)} for details
+   */
+  @CanIgnoreReturnValue
+  ChangeInfo submitRequirementsReview(BatchSubmitRequirementInput input) throws RestApiException;
 
   /**
    * A default implementation which allows source compatibility when adding new methods to the
@@ -254,6 +369,11 @@ public interface ProjectApi {
     }
 
     @Override
+    public void description(DescriptionInput in) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
     public ProjectAccessInfo access() throws RestApiException {
       throw new NotImplementedException();
     }
@@ -264,7 +384,7 @@ public interface ProjectApi {
     }
 
     @Override
-    public ChangeInfo accessChange(ProjectAccessInput input) throws RestApiException {
+    public ChangeInfo accessChange(ProjectAccessInput p) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -289,7 +409,22 @@ public interface ProjectApi {
     }
 
     @Override
-    public void description(DescriptionInput in) throws RestApiException {
+    public ChangeInfo configReview(ConfigInput in) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map<String, Set<String>> commitsIn(Collection<String> commits, Collection<String> refs) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map<String, FileInfo> diffFiles(String oldCommit, String newCommit, boolean nameOnly) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public DiffInfo diffFile(String oldCommit, String newCommit, String path) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -300,6 +435,21 @@ public interface ProjectApi {
 
     @Override
     public ListRefsRequest<TagInfo> tags() {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void deleteBranches(DeleteBranchesInput in) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public Map<DeleteChangesResult, Collection<String>> deleteChanges(DeleteChangesInput in) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void deleteTags(DeleteTagsInput in) throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -334,16 +484,6 @@ public interface ProjectApi {
     }
 
     @Override
-    public void deleteBranches(DeleteBranchesInput in) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
-    public void deleteTags(DeleteTagsInput in) throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
     public CommitApi commit(String commit) throws RestApiException {
       throw new NotImplementedException();
     }
@@ -359,17 +499,17 @@ public interface ProjectApi {
     }
 
     @Override
-    public ListDashboardsRequest dashboards() throws RestApiException {
-      throw new NotImplementedException();
-    }
-
-    @Override
     public void defaultDashboard(String name) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
     public void removeDefaultDashboard() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public ListDashboardsRequest dashboards() throws RestApiException {
       throw new NotImplementedException();
     }
 
@@ -414,7 +554,32 @@ public interface ProjectApi {
     }
 
     @Override
+    public ListSubmitRequirementsRequest submitRequirements() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public SubmitRequirementApi submitRequirement(String name) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
     public void labels(BatchLabelInput input) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public ChangeInfo labelsReview(BatchLabelInput input) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void submitRequirements(BatchSubmitRequirementInput input) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public ChangeInfo submitRequirementsReview(BatchSubmitRequirementInput input) throws RestApiException {
       throw new NotImplementedException();
     }
   }

--- a/src/main/java/com/google/gerrit/extensions/api/projects/ProjectInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/ProjectInput.java
@@ -38,4 +38,21 @@ public class ProjectInput {
   public InheritableBoolean requireSignedPush;
   public String maxObjectSizeLimit;
   public Map<String, Map<String, ConfigValue>> pluginConfigValues;
+
+  /**
+   * If set, only the project initialization is being (re-)done and the repository creation is
+   * skipped.
+   *
+   * <p>The project initialization consists out of setting {@code HEAD}, creating the {@code
+   * project.config} file in {@code refs/meta/config} and creating initial branches with empty
+   * commits.
+   *
+   * <p>This is useful to retry the project initialization after a create project request has failed
+   * and as a result the repository was created but the project initialization was not done.
+   *
+   * <p>Note, that this does not override any existing project configuration.
+   *
+   * <p>If a conflicting configuration already exists the request is rejected with `409 Conflict`.
+   */
+  public boolean initOnly;
 }

--- a/src/main/java/com/google/gerrit/extensions/api/projects/Projects.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/Projects.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.extensions.api.projects;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.extensions.client.ProjectState;
 import com.google.gerrit.extensions.common.ProjectInfo;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
@@ -46,6 +47,7 @@ public interface Projects {
    * @return API for accessing the newly-created project.
    * @throws RestApiException if an error occurred.
    */
+  @CanIgnoreReturnValue
   ProjectApi create(String name) throws RestApiException;
 
   /**
@@ -55,6 +57,7 @@ public interface Projects {
    * @return API for accessing the newly-created project.
    * @throws RestApiException if an error occurred.
    */
+  @CanIgnoreReturnValue
   ProjectApi create(ProjectInput in) throws RestApiException;
 
   ListRequest list();
@@ -270,12 +273,12 @@ public interface Projects {
     }
 
     @Override
-    public ProjectApi create(ProjectInput in) throws RestApiException {
+    public ProjectApi create(String name) throws RestApiException {
       throw new NotImplementedException();
     }
 
     @Override
-    public ProjectApi create(String name) throws RestApiException {
+    public ProjectApi create(ProjectInput in) throws RestApiException {
       throw new NotImplementedException();
     }
 

--- a/src/main/java/com/google/gerrit/extensions/api/projects/SubmitRequirementApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/SubmitRequirementApi.java
@@ -1,0 +1,63 @@
+// Copyright (C) 2022 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.api.projects;
+
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.gerrit.extensions.common.SubmitRequirementInfo;
+import com.google.gerrit.extensions.common.SubmitRequirementInput;
+import com.google.gerrit.extensions.restapi.NotImplementedException;
+import com.google.gerrit.extensions.restapi.RestApiException;
+
+public interface SubmitRequirementApi {
+  /** Create a new submit requirement. */
+  @CanIgnoreReturnValue
+  SubmitRequirementApi create(SubmitRequirementInput input) throws RestApiException;
+
+  /** Get existing submit requirement. */
+  SubmitRequirementInfo get() throws RestApiException;
+
+  /** Update existing submit requirement. */
+  @CanIgnoreReturnValue
+  SubmitRequirementInfo update(SubmitRequirementInput input) throws RestApiException;
+
+  /** Delete existing submit requirement. */
+  void delete() throws RestApiException;
+
+  /**
+   * A default implementation which allows source compatibility when adding new methods to the
+   * interface.
+   */
+  class NotImplemented implements SubmitRequirementApi {
+    @Override
+    public SubmitRequirementApi create(SubmitRequirementInput input) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public SubmitRequirementInfo get() throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public SubmitRequirementInfo update(SubmitRequirementInput input) throws RestApiException {
+      throw new NotImplementedException();
+    }
+
+    @Override
+    public void delete() throws RestApiException {
+      throw new NotImplementedException();
+    }
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/api/projects/TagApi.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/TagApi.java
@@ -14,10 +14,12 @@
 
 package com.google.gerrit.extensions.api.projects;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.gerrit.extensions.restapi.NotImplementedException;
 import com.google.gerrit.extensions.restapi.RestApiException;
 
 public interface TagApi {
+  @CanIgnoreReturnValue
   TagApi create(TagInput input) throws RestApiException;
 
   TagInfo get() throws RestApiException;

--- a/src/main/java/com/google/gerrit/extensions/api/projects/TagInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/TagInfo.java
@@ -14,16 +14,22 @@
 
 package com.google.gerrit.extensions.api.projects;
 
+import com.google.gerrit.common.Nullable;
 import com.google.gerrit.extensions.common.GitPerson;
 import com.google.gerrit.extensions.common.WebLinkInfo;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 
 public class TagInfo extends RefInfo {
   public String object;
   public String message;
   public GitPerson tagger;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp created;
+
   public List<WebLinkInfo> webLinks;
 
   public TagInfo(
@@ -39,8 +45,22 @@ public class TagInfo extends RefInfo {
     this.created = created;
   }
 
+  @SuppressWarnings("JdkObsolete")
+  public TagInfo(
+      String ref,
+      String revision,
+      Boolean canDelete,
+      List<WebLinkInfo> webLinks,
+      @Nullable Instant created) {
+    this.ref = ref;
+    this.revision = revision;
+    this.canDelete = canDelete;
+    this.webLinks = webLinks;
+    this.created = created != null ? Timestamp.from(created) : null;
+  }
+
   public TagInfo(String ref, String revision, Boolean canDelete, List<WebLinkInfo> webLinks) {
-    this(ref, revision, canDelete, webLinks, null);
+    this(ref, revision, canDelete, webLinks, (Instant) null);
   }
 
   public TagInfo(
@@ -66,8 +86,24 @@ public class TagInfo extends RefInfo {
       String message,
       GitPerson tagger,
       Boolean canDelete,
+      List<WebLinkInfo> webLinks,
+      Instant created) {
+    this(ref, revision, canDelete, webLinks, created);
+    this.object = object;
+    this.message = message;
+    this.tagger = tagger;
+    this.webLinks = webLinks;
+  }
+
+  public TagInfo(
+      String ref,
+      String revision,
+      String object,
+      String message,
+      GitPerson tagger,
+      Boolean canDelete,
       List<WebLinkInfo> webLinks) {
-    this(ref, revision, object, message, tagger, canDelete, webLinks, null);
+    this(ref, revision, object, message, tagger, canDelete, webLinks, (Instant) null);
     this.object = object;
     this.message = message;
     this.tagger = tagger;

--- a/src/main/java/com/google/gerrit/extensions/api/projects/TagInput.java
+++ b/src/main/java/com/google/gerrit/extensions/api/projects/TagInput.java
@@ -15,9 +15,14 @@
 package com.google.gerrit.extensions.api.projects;
 
 import com.google.gerrit.extensions.restapi.DefaultInput;
+import java.sql.Timestamp;
 
 public class TagInput {
   @DefaultInput public String ref;
   public String revision;
   public String message;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  public Timestamp date;
 }

--- a/src/main/java/com/google/gerrit/extensions/auth/AuthTokenInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/auth/AuthTokenInfo.java
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.auth;
+
+import com.google.gerrit.common.Nullable;
+import java.sql.Timestamp;
+
+public class AuthTokenInfo {
+  public String id;
+  /* Should only be set when the token is being created. */
+  @Nullable public String token;
+  @Nullable public Timestamp expiration;
+}

--- a/src/main/java/com/google/gerrit/extensions/auth/AuthTokenInput.java
+++ b/src/main/java/com/google/gerrit/extensions/auth/AuthTokenInput.java
@@ -1,0 +1,42 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.auth;
+
+import com.google.gerrit.common.ConvertibleToProto;
+import com.google.gerrit.common.Nullable;
+import java.util.Objects;
+
+@ConvertibleToProto
+public class AuthTokenInput {
+  @Nullable public String id;
+  @Nullable public String token;
+  @Nullable public String lifetime;
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, token, lifetime);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof AuthTokenInput)) {
+      return false;
+    }
+    AuthTokenInput other = (AuthTokenInput) obj;
+    return Objects.equals(id, other.id)
+        && Objects.equals(token, other.token)
+        && Objects.equals(lifetime, other.lifetime);
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/client/ChangeKind.java
+++ b/src/main/java/com/google/gerrit/extensions/client/ChangeKind.java
@@ -22,6 +22,12 @@ public enum ChangeKind {
   /** Conflict-free merge between the new parent and the prior patch set. */
   TRIVIAL_REBASE,
 
+  /**
+   * Conflict-free merge between the new parent and the prior patch set, accompanied with a change
+   * to commit message.
+   */
+  TRIVIAL_REBASE_WITH_MESSAGE_UPDATE,
+
   /** Conflict-free change of first (left) parent of a merge commit. */
   MERGE_FIRST_PARENT_UPDATE,
 
@@ -29,5 +35,53 @@ public enum ChangeKind {
   NO_CODE_CHANGE,
 
   /** Same tree, parent tree, same commit message. */
-  NO_CHANGE
+  NO_CHANGE;
+
+  public boolean matches(ChangeKind changeKind, boolean isMerge) {
+    switch (changeKind) {
+      case REWORK:
+        // REWORK includes all other change kinds, since those are just more trivial cases of a
+        // rework
+        return true;
+      case TRIVIAL_REBASE:
+        return isTrivialRebase();
+      case TRIVIAL_REBASE_WITH_MESSAGE_UPDATE:
+        return isTrivialRebaseWithMessageUpdate();
+      case MERGE_FIRST_PARENT_UPDATE:
+        return isMergeFirstParentUpdate(isMerge);
+      case NO_CHANGE:
+        return this == NO_CHANGE;
+      case NO_CODE_CHANGE:
+        return isNoCodeChange();
+      default:
+        throw new IllegalStateException("unexpected ChangeKind: " + changeKind);
+    }
+  }
+
+  public boolean isNoCodeChange() {
+    // NO_CHANGE is a more trivial case of NO_CODE_CHANGE and hence matched as well
+    return this == NO_CHANGE || this == NO_CODE_CHANGE;
+  }
+
+  public boolean isTrivialRebase() {
+    // NO_CHANGE is a more trivial case of TRIVIAL_REBASE and hence matched as well
+    return this == NO_CHANGE || this == TRIVIAL_REBASE;
+  }
+
+  public boolean isTrivialRebaseWithMessageUpdate() {
+    // TRIVIAL_REBASE is more strict condition and hence matched as well
+    return this == NO_CHANGE
+        || this == NO_CODE_CHANGE
+        || this == TRIVIAL_REBASE
+        || this == TRIVIAL_REBASE_WITH_MESSAGE_UPDATE;
+  }
+
+  public boolean isMergeFirstParentUpdate(boolean isMerge) {
+    if (!isMerge) {
+      return false;
+    }
+
+    // NO_CHANGE is a more trivial case of MERGE_FIRST_PARENT_UPDATE and hence matched as well
+    return this == NO_CHANGE || this == MERGE_FIRST_PARENT_UPDATE;
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/client/ChangeStatus.java
+++ b/src/main/java/com/google/gerrit/extensions/client/ChangeStatus.java
@@ -31,50 +31,7 @@ public enum ChangeStatus {
    *   <li>{@link #ABANDONED} - when the Abandon action is used.
    * </ul>
    */
-  NEW,
-
-  /**
-   * Change is open, but has been submitted to the merge queue.
-   *
-   * <p>
-   * A change enters the SUBMITTED state when an authorized user presses the
-   * "submit" action through the web UI, requesting that Gerrit merge the
-   * change's current patch set into the destination branch.
-   *
-   * <p>
-   * Typically a change resides in the SUBMITTED for only a brief sub-second
-   * period while the merge queue fires and the destination branch is updated.
-   * However, if a dependency commit (directly or transitively) is not yet
-   * merged into the branch, the change will hang in the SUBMITTED state
-   * indefinitely.
-   *
-   * <p>
-   * Changes in the SUBMITTED state can be moved to:
-   * <ul>
-   * <li>{@link #NEW} - when a replacement patch set is supplied, OR when a
-   * merge conflict is detected;
-   * <li>{@link #MERGED} - when the change has been successfully merged into
-   * the destination branch;
-   * <li>{@link #ABANDONED} - when the Abandon action is used.
-   * </ul>
-   */
-  SUBMITTED,
-
-  /**
-   * Change is a draft change that only consists of draft patchsets.
-   *
-   * <p>This is a change that is not meant to be submitted or reviewed yet. If the uploader
-   * publishes the change, it becomes a NEW change. Publishing is a one-way action, a change cannot
-   * return to DRAFT status. Draft changes are only visible to the uploader and those explicitly
-   * added as reviewers. Note that currently draft changes cannot be abandoned.
-   *
-   * <p>Changes in the DRAFT state can be moved to:
-   *
-   * <ul>
-   *   <li>{@link #NEW} - when the change is published, it becomes a new change.
-   * </ul>
-   */
-  DRAFT,
+  NEW(0),
 
   /**
    * Change is closed, and submitted to its destination branch.
@@ -82,7 +39,7 @@ public enum ChangeStatus {
    * <p>Once a change has been merged, it cannot be further modified by adding a replacement patch
    * set. Draft comments however may be published, supporting a post-submit review.
    */
-  MERGED,
+  MERGED(1),
 
   /**
    * Change is closed, but was not submitted to its destination branch.
@@ -97,5 +54,32 @@ public enum ChangeStatus {
    *   <li>{@link #NEW} - when the Restore action is used.
    * </ul>
    */
-  ABANDONED
+  ABANDONED(2),
+
+  /**
+   * @deprecated removed upstream. Change is open, but has been submitted to the merge queue.
+   *     Typically a change resides in the SUBMITTED state for only a brief sub-second period while
+   *     the merge queue fires and the destination branch is updated. However, if a dependency commit
+   *     (directly or transitively) is not yet merged into the branch, the change will hang in the
+   *     SUBMITTED state indefinitely.
+   */
+  @Deprecated
+  SUBMITTED(3),
+
+  /**
+   * @deprecated removed upstream along with the "draft change" feature. Change is a draft change
+   *     that only consists of draft patchsets, not meant to be submitted or reviewed yet.
+   */
+  @Deprecated
+  DRAFT(4);
+
+  private final int value;
+
+  ChangeStatus(int v) {
+    this.value = v;
+  }
+
+  public int getValue() {
+    return value;
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/client/Comment.java
+++ b/src/main/java/com/google/gerrit/extensions/client/Comment.java
@@ -40,6 +40,11 @@ public abstract class Comment {
   public Range range;
   public String inReplyTo;
 
+  // Removed upstream from this shared base class (moved into individual subclasses instead). Kept
+  // here for source/binary compatibility with existing callers that reference it via a Comment-typed
+  // value; CommentInfo/DraftInput/ReviewInput.CommentInput inherit it rather than re-declaring it.
+  public Boolean unresolved;
+
   // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
   // Instant
   public Timestamp updated;
@@ -156,6 +161,7 @@ public abstract class Comment {
           && Objects.equals(line, c.line)
           && Objects.equals(range, c.range)
           && Objects.equals(inReplyTo, c.inReplyTo)
+          && Objects.equals(unresolved, c.unresolved)
           && Objects.equals(updated, c.updated)
           && Objects.equals(message, c.message)
           && Objects.equals(commitId, c.commitId)
@@ -176,6 +182,7 @@ public abstract class Comment {
         line,
         range,
         inReplyTo,
+        unresolved,
         updated,
         message,
         fixSuggestions,

--- a/src/main/java/com/google/gerrit/extensions/client/Comment.java
+++ b/src/main/java/com/google/gerrit/extensions/client/Comment.java
@@ -14,8 +14,11 @@
 
 package com.google.gerrit.extensions.client;
 
+import com.google.gerrit.extensions.common.FixSuggestionInfo;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
 
 public abstract class Comment {
@@ -30,20 +33,42 @@ public abstract class Comment {
   public String path;
   public Side side;
   public Integer parent;
+
   /** Value 0 or null indicates a file comment, normal lines start at 1. */
   public Integer line;
 
   public Range range;
   public String inReplyTo;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp updated;
+
   public String message;
-  public Boolean unresolved;
 
   /**
    * Hex commit SHA1 (as 40 characters hex string) of the commit of the patchset to which this
    * comment applies.
    */
   public String commitId;
+
+  public List<FixSuggestionInfo> fixSuggestions;
+
+  public Boolean isAi;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public Instant getUpdated() {
+    return updated.toInstant();
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public void setUpdated(Instant when) {
+    updated = Timestamp.from(when);
+  }
 
   public static class Range implements Comparable<Range> {
     private static final Comparator<Range> RANGE_COMPARATOR =
@@ -71,10 +96,10 @@ public abstract class Comment {
     public boolean equals(Object o) {
       if (o instanceof Range) {
         Range r = (Range) o;
-        return Objects.equals(startLine, r.startLine)
-            && Objects.equals(startCharacter, r.startCharacter)
-            && Objects.equals(endLine, r.endLine)
-            && Objects.equals(endCharacter, r.endCharacter);
+        return startLine == r.startLine
+            && startCharacter == r.startCharacter
+            && endLine == r.endLine
+            && endCharacter == r.endCharacter;
       }
       return false;
     }
@@ -111,6 +136,11 @@ public abstract class Comment {
     return 1;
   }
 
+  // This is a value class that allows adding attributes by subclassing.
+  // Doing this is discouraged and using composition rather than inheritance to add fields to value
+  // types is preferred. However this class is part of the extension API, hence we cannot change it
+  // without breaking the API. Hence suppress the EqualsGetClass warning here.
+  @SuppressWarnings("EqualsGetClass")
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -128,14 +158,27 @@ public abstract class Comment {
           && Objects.equals(inReplyTo, c.inReplyTo)
           && Objects.equals(updated, c.updated)
           && Objects.equals(message, c.message)
-          && Objects.equals(unresolved, c.unresolved)
-          && Objects.equals(commitId, c.commitId);
+          && Objects.equals(commitId, c.commitId)
+          && Objects.equals(fixSuggestions, c.fixSuggestions)
+          && Objects.equals(isAi, c.isAi);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(patchSet, id, path, side, parent, line, range, inReplyTo, updated, message);
+    return Objects.hash(
+        patchSet,
+        id,
+        path,
+        side,
+        parent,
+        line,
+        range,
+        inReplyTo,
+        updated,
+        message,
+        fixSuggestions,
+        isAi);
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/client/DiffPreferencesInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/client/DiffPreferencesInfo.java
@@ -14,6 +14,13 @@
 
 package com.google.gerrit.extensions.client;
 
+import static com.google.gerrit.extensions.client.NullableBooleanPreferencesFieldComparator.equalBooleanPreferencesFields;
+
+import com.google.common.base.MoreObjects;
+import com.google.gerrit.common.ConvertibleToProto;
+import java.util.Objects;
+
+@ConvertibleToProto
 public class DiffPreferencesInfo {
 
   /** Default number of lines of context. */
@@ -28,10 +35,11 @@ public class DiffPreferencesInfo {
   /** Default line length. */
   public static final int DEFAULT_LINE_LENGTH = 100;
 
-  /** Context setting to display the entire file. */
-  public static final short WHOLE_FILE_CONTEXT = -1;
+  /** @deprecated removed upstream. Context setting to display the entire file. */
+  @Deprecated public static final short WHOLE_FILE_CONTEXT = -1;
 
-  /** Typical valid choices for the default context setting. */
+  /** @deprecated removed upstream. Typical valid choices for the default context setting. */
+  @Deprecated
   public static final short[] CONTEXT_CHOICES = {3, 10, 25, 50, 75, 100, WHOLE_FILE_CONTEXT};
 
   public enum Whitespace {
@@ -39,6 +47,12 @@ public class DiffPreferencesInfo {
     IGNORE_TRAILING,
     IGNORE_LEADING_AND_TRAILING,
     IGNORE_ALL
+  }
+
+  public enum ResponsiveMode {
+    NONE,
+    SHRINK_ONLY,
+    FULL_RESPONSIVE
   }
 
   public Integer context;
@@ -59,12 +73,108 @@ public class DiffPreferencesInfo {
   public Boolean renderEntireFile;
   public Boolean hideEmptyPane;
   public Boolean matchBrackets;
-  public Boolean lineWrapping;
+  @Deprecated public Boolean lineWrapping;
+  public ResponsiveMode responsiveMode;
   public Whitespace ignoreWhitespace;
   public Boolean retainHeader;
   public Boolean skipDeleted;
   public Boolean skipUnchanged;
   public Boolean skipUncommented;
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof DiffPreferencesInfo)) {
+      return false;
+    }
+    DiffPreferencesInfo other = (DiffPreferencesInfo) obj;
+    return Objects.equals(this.context, other.context)
+        && Objects.equals(this.tabSize, other.tabSize)
+        && Objects.equals(this.fontSize, other.fontSize)
+        && Objects.equals(this.lineLength, other.lineLength)
+        && Objects.equals(this.cursorBlinkRate, other.cursorBlinkRate)
+        && equalBooleanPreferencesFields(this.expandAllComments, other.expandAllComments)
+        && equalBooleanPreferencesFields(this.intralineDifference, other.intralineDifference)
+        && equalBooleanPreferencesFields(this.manualReview, other.manualReview)
+        && equalBooleanPreferencesFields(this.showLineEndings, other.showLineEndings)
+        && equalBooleanPreferencesFields(this.showTabs, other.showTabs)
+        && equalBooleanPreferencesFields(this.showWhitespaceErrors, other.showWhitespaceErrors)
+        && equalBooleanPreferencesFields(this.syntaxHighlighting, other.syntaxHighlighting)
+        && equalBooleanPreferencesFields(this.hideTopMenu, other.hideTopMenu)
+        && equalBooleanPreferencesFields(
+            this.autoHideDiffTableHeader, other.autoHideDiffTableHeader)
+        && equalBooleanPreferencesFields(this.hideLineNumbers, other.hideLineNumbers)
+        && equalBooleanPreferencesFields(this.renderEntireFile, other.renderEntireFile)
+        && equalBooleanPreferencesFields(this.hideEmptyPane, other.hideEmptyPane)
+        && equalBooleanPreferencesFields(this.matchBrackets, other.matchBrackets)
+        && equalBooleanPreferencesFields(this.lineWrapping, other.lineWrapping)
+        && Objects.equals(this.responsiveMode, other.responsiveMode)
+        && Objects.equals(this.ignoreWhitespace, other.ignoreWhitespace)
+        && equalBooleanPreferencesFields(this.retainHeader, other.retainHeader)
+        && equalBooleanPreferencesFields(this.skipDeleted, other.skipDeleted)
+        && equalBooleanPreferencesFields(this.skipUnchanged, other.skipUnchanged)
+        && equalBooleanPreferencesFields(this.skipUncommented, other.skipUncommented);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        context,
+        tabSize,
+        fontSize,
+        lineLength,
+        cursorBlinkRate,
+        expandAllComments,
+        intralineDifference,
+        manualReview,
+        showLineEndings,
+        showTabs,
+        showWhitespaceErrors,
+        syntaxHighlighting,
+        hideTopMenu,
+        autoHideDiffTableHeader,
+        hideLineNumbers,
+        renderEntireFile,
+        hideEmptyPane,
+        matchBrackets,
+        lineWrapping,
+        responsiveMode,
+        ignoreWhitespace,
+        retainHeader,
+        skipDeleted,
+        skipUnchanged,
+        skipUncommented);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper("DiffPreferencesInfo")
+        .add("context", context)
+        .add("tabSize", tabSize)
+        .add("fontSize", fontSize)
+        .add("lineLength", lineLength)
+        .add("cursorBlinkRate", cursorBlinkRate)
+        .add("expandAllComments", expandAllComments)
+        .add("intralineDifference", intralineDifference)
+        .add("manualReview", manualReview)
+        .add("showLineEndings", showLineEndings)
+        .add("showTabs", showTabs)
+        .add("showWhitespaceErrors", showWhitespaceErrors)
+        .add("syntaxHighlighting", syntaxHighlighting)
+        .add("hideTopMenu", hideTopMenu)
+        .add("autoHideDiffTableHeader", autoHideDiffTableHeader)
+        .add("hideLineNumbers", hideLineNumbers)
+        .add("renderEntireFile", renderEntireFile)
+        .add("hideEmptyPane", hideEmptyPane)
+        .add("matchBrackets", matchBrackets)
+        .add("lineWrapping", lineWrapping)
+        .add("responsiveMode", responsiveMode)
+        .add("ignoreWhitespace", ignoreWhitespace)
+        .add("retainHeader", retainHeader)
+        .add("skipDeleted", skipDeleted)
+        .add("skipUnchanged", skipUnchanged)
+        .add("skipUncommented", skipUncommented)
+        .toString();
+  }
 
   public static DiffPreferencesInfo defaults() {
     DiffPreferencesInfo i = new DiffPreferencesInfo();
@@ -87,6 +197,7 @@ public class DiffPreferencesInfo {
     i.hideEmptyPane = false;
     i.matchBrackets = false;
     i.lineWrapping = false;
+    i.responsiveMode = ResponsiveMode.NONE;
     i.ignoreWhitespace = Whitespace.IGNORE_NONE;
     i.retainHeader = false;
     i.skipDeleted = false;

--- a/src/main/java/com/google/gerrit/extensions/client/EditPreferencesInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/client/EditPreferencesInfo.java
@@ -14,7 +14,14 @@
 
 package com.google.gerrit.extensions.client;
 
+import static com.google.gerrit.extensions.client.NullableBooleanPreferencesFieldComparator.equalBooleanPreferencesFields;
+
+import com.google.common.base.MoreObjects;
+import com.google.gerrit.common.ConvertibleToProto;
+import java.util.Objects;
+
 /* This class is stored in Git config file. */
+@ConvertibleToProto
 public class EditPreferencesInfo {
   public Integer tabSize;
   public Integer lineLength;
@@ -30,6 +37,67 @@ public class EditPreferencesInfo {
   public Boolean indentWithTabs;
   public Boolean autoCloseBrackets;
   public Boolean showBase;
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof EditPreferencesInfo)) {
+      return false;
+    }
+    EditPreferencesInfo other = (EditPreferencesInfo) obj;
+    return Objects.equals(this.tabSize, other.tabSize)
+        && Objects.equals(this.lineLength, other.lineLength)
+        && Objects.equals(this.indentUnit, other.indentUnit)
+        && Objects.equals(this.cursorBlinkRate, other.cursorBlinkRate)
+        && equalBooleanPreferencesFields(this.hideTopMenu, other.hideTopMenu)
+        && equalBooleanPreferencesFields(this.showTabs, other.showTabs)
+        && equalBooleanPreferencesFields(this.showWhitespaceErrors, other.showWhitespaceErrors)
+        && equalBooleanPreferencesFields(this.syntaxHighlighting, other.syntaxHighlighting)
+        && equalBooleanPreferencesFields(this.hideLineNumbers, other.hideLineNumbers)
+        && equalBooleanPreferencesFields(this.matchBrackets, other.matchBrackets)
+        && equalBooleanPreferencesFields(this.lineWrapping, other.lineWrapping)
+        && equalBooleanPreferencesFields(this.indentWithTabs, other.indentWithTabs)
+        && equalBooleanPreferencesFields(this.autoCloseBrackets, other.autoCloseBrackets)
+        && equalBooleanPreferencesFields(this.showBase, other.showBase);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        tabSize,
+        lineLength,
+        indentUnit,
+        cursorBlinkRate,
+        hideTopMenu,
+        showTabs,
+        showWhitespaceErrors,
+        syntaxHighlighting,
+        hideLineNumbers,
+        matchBrackets,
+        lineWrapping,
+        indentWithTabs,
+        autoCloseBrackets,
+        showBase);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper("EditPreferencesInfo")
+        .add("tabSize", tabSize)
+        .add("lineLength", lineLength)
+        .add("indentUnit", indentUnit)
+        .add("cursorBlinkRate", cursorBlinkRate)
+        .add("hideTopMenu", hideTopMenu)
+        .add("showTabs", showTabs)
+        .add("showWhitespaceErrors", showWhitespaceErrors)
+        .add("syntaxHighlighting", syntaxHighlighting)
+        .add("hideLineNumbers", hideLineNumbers)
+        .add("matchBrackets", matchBrackets)
+        .add("lineWrapping", lineWrapping)
+        .add("indentWithTabs", indentWithTabs)
+        .add("autoCloseBrackets", autoCloseBrackets)
+        .add("showBase", showBase)
+        .toString();
+  }
 
   public static EditPreferencesInfo defaults() {
     EditPreferencesInfo i = new EditPreferencesInfo();

--- a/src/main/java/com/google/gerrit/extensions/client/EditPreferencesInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/client/EditPreferencesInfo.java
@@ -67,16 +67,16 @@ public class EditPreferencesInfo {
         lineLength,
         indentUnit,
         cursorBlinkRate,
-        hideTopMenu,
-        showTabs,
-        showWhitespaceErrors,
-        syntaxHighlighting,
-        hideLineNumbers,
-        matchBrackets,
-        lineWrapping,
-        indentWithTabs,
-        autoCloseBrackets,
-        showBase);
+        Objects.requireNonNullElse(hideTopMenu, false),
+        Objects.requireNonNullElse(showTabs, false),
+        Objects.requireNonNullElse(showWhitespaceErrors, false),
+        Objects.requireNonNullElse(syntaxHighlighting, false),
+        Objects.requireNonNullElse(hideLineNumbers, false),
+        Objects.requireNonNullElse(matchBrackets, false),
+        Objects.requireNonNullElse(lineWrapping, false),
+        Objects.requireNonNullElse(indentWithTabs, false),
+        Objects.requireNonNullElse(autoCloseBrackets, false),
+        Objects.requireNonNullElse(showBase, false));
   }
 
   @Override

--- a/src/main/java/com/google/gerrit/extensions/client/GeneralPreferencesInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/client/GeneralPreferencesInfo.java
@@ -14,18 +14,25 @@
 
 package com.google.gerrit.extensions.client;
 
+import static com.google.gerrit.extensions.client.NullableBooleanPreferencesFieldComparator.equalBooleanPreferencesFields;
+
+import com.google.common.base.MoreObjects;
+import com.google.gerrit.common.ConvertibleToProto;
 import java.util.List;
+import java.util.Objects;
 
 /** Preferences about a single user. */
+@ConvertibleToProto
 public class GeneralPreferencesInfo {
 
   /** Default number of items to display per page. */
   public static final int DEFAULT_PAGESIZE = 25;
 
-  /** Valid choices for the page size. */
-  public static final int[] PAGESIZE_CHOICES = {10, 25, 50, 100};
+  /** @deprecated removed upstream. Valid choices for the page size. */
+  @Deprecated public static final int[] PAGESIZE_CHOICES = {10, 25, 50, 100};
 
-  /** Preferred method to download a change. */
+  /** @deprecated removed upstream. Preferred method to download a change. */
+  @Deprecated
   public enum DownloadCommand {
     REPO_DOWNLOAD,
     PULL,
@@ -75,6 +82,7 @@ public class GeneralPreferencesInfo {
   public enum EmailStrategy {
     ENABLED,
     CC_ON_OWN_COMMENTS,
+    ATTENTION_SET_ONLY,
     DISABLED
   }
 
@@ -103,6 +111,7 @@ public class GeneralPreferencesInfo {
   }
 
   public enum Theme {
+    AUTO,
     DARK,
     LIGHT
   }
@@ -127,6 +136,7 @@ public class GeneralPreferencesInfo {
 
   /** Number of changes to show in a screen. */
   public Integer changesPerPage;
+
   /** Type of download URL the user prefers to use. */
   public String downloadScheme;
 
@@ -134,7 +144,6 @@ public class GeneralPreferencesInfo {
   public DateFormat dateFormat;
   public TimeFormat timeFormat;
   public Boolean expandInlineDiffs;
-  public Boolean highlightAssigneeInChangeTable;
   public Boolean relativeDateInChangeTable;
   public DiffView diffView;
   public Boolean sizeBarInChangeTable;
@@ -145,9 +154,27 @@ public class GeneralPreferencesInfo {
   public EmailFormat emailFormat;
   public DefaultBase defaultBaseForMerges;
   public Boolean publishCommentsOnPush;
+  public Boolean disableKeyboardShortcuts;
+  public Boolean disableTokenHighlighting;
   public Boolean workInProgressByDefault;
   public List<MenuItem> my;
   public List<String> changeTable;
+  public Boolean allowBrowserNotifications;
+  public Boolean allowSuggestCodeWhileCommenting;
+  public Boolean allowAutocompletingComments;
+  public String aiChatSelectedModel;
+  public String labelFilter;
+
+  /** @deprecated removed upstream along with the "assignee" feature (superseded by attention set). */
+  @Deprecated public Boolean highlightAssigneeInChangeTable;
+
+  /**
+   * The sidebar section that the user prefers to have open on the diff page, or "NONE" if all
+   * sidebars should be closed.
+   *
+   * <p>Sidebars supplied by plugins are prefixed with "plugin-".
+   */
+  public String diffPageSidebar;
 
   public DateFormat getDateFormat() {
     if (dateFormat == null) {
@@ -184,15 +211,121 @@ public class GeneralPreferencesInfo {
     return emailFormat;
   }
 
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof GeneralPreferencesInfo)) {
+      return false;
+    }
+    GeneralPreferencesInfo other = (GeneralPreferencesInfo) obj;
+    return Objects.equals(this.changesPerPage, other.changesPerPage)
+        && Objects.equals(this.downloadScheme, other.downloadScheme)
+        && Objects.equals(this.theme, other.theme)
+        && Objects.equals(this.dateFormat, other.dateFormat)
+        && Objects.equals(this.timeFormat, other.timeFormat)
+        && equalBooleanPreferencesFields(this.expandInlineDiffs, other.expandInlineDiffs)
+        && equalBooleanPreferencesFields(
+            this.relativeDateInChangeTable, other.relativeDateInChangeTable)
+        && Objects.equals(this.diffView, other.diffView)
+        && equalBooleanPreferencesFields(this.sizeBarInChangeTable, other.sizeBarInChangeTable)
+        && equalBooleanPreferencesFields(this.legacycidInChangeTable, other.legacycidInChangeTable)
+        && equalBooleanPreferencesFields(this.muteCommonPathPrefixes, other.muteCommonPathPrefixes)
+        && equalBooleanPreferencesFields(this.signedOffBy, other.signedOffBy)
+        && Objects.equals(this.emailStrategy, other.emailStrategy)
+        && Objects.equals(this.emailFormat, other.emailFormat)
+        && Objects.equals(this.defaultBaseForMerges, other.defaultBaseForMerges)
+        && equalBooleanPreferencesFields(this.publishCommentsOnPush, other.publishCommentsOnPush)
+        && equalBooleanPreferencesFields(
+            this.disableKeyboardShortcuts, other.disableKeyboardShortcuts)
+        && equalBooleanPreferencesFields(
+            this.disableTokenHighlighting, other.disableTokenHighlighting)
+        && equalBooleanPreferencesFields(
+            this.workInProgressByDefault, other.workInProgressByDefault)
+        && Objects.equals(this.my, other.my)
+        && Objects.equals(this.changeTable, other.changeTable)
+        && equalBooleanPreferencesFields(
+            this.allowBrowserNotifications, other.allowBrowserNotifications)
+        && equalBooleanPreferencesFields(
+            this.allowSuggestCodeWhileCommenting, other.allowSuggestCodeWhileCommenting)
+        && equalBooleanPreferencesFields(
+            this.allowAutocompletingComments, other.allowAutocompletingComments)
+        && Objects.equals(this.diffPageSidebar, other.diffPageSidebar)
+        && Objects.equals(this.aiChatSelectedModel, other.aiChatSelectedModel)
+        && Objects.equals(this.labelFilter, other.labelFilter);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        changesPerPage,
+        downloadScheme,
+        theme,
+        dateFormat,
+        timeFormat,
+        expandInlineDiffs,
+        relativeDateInChangeTable,
+        diffView,
+        sizeBarInChangeTable,
+        legacycidInChangeTable,
+        muteCommonPathPrefixes,
+        signedOffBy,
+        emailStrategy,
+        emailFormat,
+        defaultBaseForMerges,
+        publishCommentsOnPush,
+        disableKeyboardShortcuts,
+        disableTokenHighlighting,
+        workInProgressByDefault,
+        my,
+        changeTable,
+        allowBrowserNotifications,
+        allowSuggestCodeWhileCommenting,
+        allowAutocompletingComments,
+        diffPageSidebar,
+        aiChatSelectedModel,
+        labelFilter);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper("GeneralPreferencesInfo")
+        .add("changesPerPage", changesPerPage)
+        .add("downloadScheme", downloadScheme)
+        .add("theme", theme)
+        .add("dateFormat", dateFormat)
+        .add("timeFormat", timeFormat)
+        .add("expandInlineDiffs", expandInlineDiffs)
+        .add("relativeDateInChangeTable", relativeDateInChangeTable)
+        .add("diffView", diffView)
+        .add("sizeBarInChangeTable", sizeBarInChangeTable)
+        .add("legacycidInChangeTable", legacycidInChangeTable)
+        .add("muteCommonPathPrefixes", muteCommonPathPrefixes)
+        .add("signedOffBy", signedOffBy)
+        .add("emailStrategy", emailStrategy)
+        .add("emailFormat", emailFormat)
+        .add("defaultBaseForMerges", defaultBaseForMerges)
+        .add("publishCommentsOnPush", publishCommentsOnPush)
+        .add("disableKeyboardShortcuts", disableKeyboardShortcuts)
+        .add("disableTokenHighlighting", disableTokenHighlighting)
+        .add("workInProgressByDefault", workInProgressByDefault)
+        .add("my", my)
+        .add("changeTable", changeTable)
+        .add("allowBrowserNotifications", allowBrowserNotifications)
+        .add("allowSuggestCodeWhileCommenting", allowSuggestCodeWhileCommenting)
+        .add("allowAutocompletingComments", allowAutocompletingComments)
+        .add("diffPageSidebar", diffPageSidebar)
+        .add("aiChatSelectedModel", aiChatSelectedModel)
+        .add("labelFilter", labelFilter)
+        .toString();
+  }
+
   public static GeneralPreferencesInfo defaults() {
     GeneralPreferencesInfo p = new GeneralPreferencesInfo();
     p.changesPerPage = DEFAULT_PAGESIZE;
     p.downloadScheme = null;
-    p.theme = Theme.LIGHT;
+    p.theme = Theme.AUTO;
     p.dateFormat = DateFormat.STD;
     p.timeFormat = TimeFormat.HHMM_12;
     p.expandInlineDiffs = false;
-    p.highlightAssigneeInChangeTable = true;
     p.relativeDateInChangeTable = false;
     p.diffView = DiffView.SIDE_BY_SIDE;
     p.sizeBarInChangeTable = true;
@@ -203,7 +336,15 @@ public class GeneralPreferencesInfo {
     p.emailFormat = EmailFormat.HTML_PLAINTEXT;
     p.defaultBaseForMerges = DefaultBase.FIRST_PARENT;
     p.publishCommentsOnPush = false;
+    p.disableKeyboardShortcuts = false;
+    p.disableTokenHighlighting = false;
     p.workInProgressByDefault = false;
+    p.allowBrowserNotifications = true;
+    p.allowSuggestCodeWhileCommenting = true;
+    p.allowAutocompletingComments = true;
+    p.diffPageSidebar = "NONE";
+    p.aiChatSelectedModel = null;
+    p.labelFilter = null;
     return p;
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/client/GerritTopMenu.java
+++ b/src/main/java/com/google/gerrit/extensions/client/GerritTopMenu.java
@@ -14,6 +14,8 @@
 
 package com.google.gerrit.extensions.client;
 
+import java.util.Locale;
+
 public enum GerritTopMenu {
   ALL,
   MY,
@@ -25,6 +27,6 @@ public enum GerritTopMenu {
   public final String menuName;
 
   GerritTopMenu() {
-    menuName = name().substring(0, 1) + name().substring(1).toLowerCase();
+    menuName = name().substring(0, 1) + name().substring(1).toLowerCase(Locale.US);
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/client/ListChangesOption.java
+++ b/src/main/java/com/google/gerrit/extensions/client/ListChangesOption.java
@@ -85,7 +85,22 @@ public enum ListChangesOption implements ListOption {
    * Skip diffstat computation that compute the insertions field (number of lines inserted) and
    * deletions field (number of lines deleted)
    */
-  SKIP_DIFFSTAT(23);
+  SKIP_DIFFSTAT(23),
+
+  /** Include the evaluated submit requirements for the caller. */
+  SUBMIT_REQUIREMENTS(24),
+
+  /** Include custom keyed values. */
+  CUSTOM_KEYED_VALUES(25),
+
+  /** Include the 'starred' field, that is if the change is starred by the current user . */
+  STAR(26),
+
+  /**
+   * Include the `parents_data` field in each revision, e.g. if it's merged in the target branch and
+   * whether it points to a patch-set of another change.
+   */
+  PARENTS(27);
 
   private final int value;
 

--- a/src/main/java/com/google/gerrit/extensions/client/MenuItem.java
+++ b/src/main/java/com/google/gerrit/extensions/client/MenuItem.java
@@ -14,8 +14,10 @@
 
 package com.google.gerrit.extensions.client;
 
+import com.google.gerrit.common.ConvertibleToProto;
 import java.util.Objects;
 
+@ConvertibleToProto
 public class MenuItem {
   public final String url;
   public final String name;

--- a/src/main/java/com/google/gerrit/extensions/client/NullableBooleanPreferencesFieldComparator.java
+++ b/src/main/java/com/google/gerrit/extensions/client/NullableBooleanPreferencesFieldComparator.java
@@ -1,0 +1,56 @@
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.client;
+
+import com.google.gerrit.common.Nullable;
+import java.util.Objects;
+
+/**
+ * Utility class to compare nullable {@link Boolean} preferences fields.
+ *
+ * <p>This class only meant to be used for comparing preferences fields that are potentially loaded
+ * using {@link com.google.gerrit.server.config.ConfigUtil} (such as {@link GeneralPreferencesInfo},
+ * {@link DiffPreferencesInfo} and {@link EditPreferencesInfo}).
+ */
+public class NullableBooleanPreferencesFieldComparator {
+
+  /**
+   * Compare 2 nullable {@link Boolean} preferences fields, regard to {@code null} as {@code false}.
+   *
+   * <p>{@link com.google.gerrit.server.config.ConfigUtil#loadSection} sets the following values for
+   * Boolean fields, relating to {@code null} as {@code false} the same way:
+   *
+   * <table>
+   *   <tr><th> user-def </th> <th> default </th> <th> result </th></tr>
+   *   <tr><td> true </td> <td> true </td> <td> true </td></tr>
+   *   <tr><td> true </td> <td> false </td> <td> true </td></tr>
+   *   <tr><td> true </td> <td> null </td> <td> true </td></tr>
+   *   <tr><td> false </td> <td> true </td> <td> false </td></tr>
+   *   <tr><td> false </td> <td> false </td> <td> null </td></tr>
+   *   <tr><td> false </td> <td> null </td> <td> null </td></tr>
+   *   <tr><td> null </td> <td> true </td> <td> true </td></tr>
+   *   <tr><td> null </td> <td> false </td> <td> null </td></tr>
+   *   <tr><td> null </td> <td> null </td> <td> null </td></tr>
+   * </table>
+   *
+   * When reading the values, the readers always check whether the value is {@code true},
+   * practically referring to {@code null} values as {@code false} anyway. Preferences equality
+   * methods should reflect this state.
+   */
+  public static boolean equalBooleanPreferencesFields(@Nullable Boolean a, @Nullable Boolean b) {
+    return Objects.equals(
+        Objects.requireNonNullElse(a, false), Objects.requireNonNullElse(b, false));
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/client/ProjectWatchInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/client/ProjectWatchInfo.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 public class ProjectWatchInfo {
   public String project;
   public String filter;
+  public String problem;
 
   public Boolean notifyNewChanges;
   public Boolean notifyNewPatchSets;
@@ -32,6 +33,7 @@ public class ProjectWatchInfo {
       ProjectWatchInfo w = (ProjectWatchInfo) obj;
       return Objects.equals(project, w.project)
           && Objects.equals(filter, w.filter)
+          && Objects.equals(problem, w.problem)
           && Objects.equals(notifyNewChanges, w.notifyNewChanges)
           && Objects.equals(notifyNewPatchSets, w.notifyNewPatchSets)
           && Objects.equals(notifyAllComments, w.notifyAllComments)
@@ -46,6 +48,7 @@ public class ProjectWatchInfo {
     return Objects.hash(
         project,
         filter,
+        problem,
         notifyNewChanges,
         notifyNewPatchSets,
         notifyAllComments,
@@ -54,11 +57,15 @@ public class ProjectWatchInfo {
   }
 
   @Override
+  @SuppressWarnings("OrphanedFormatString")
   public String toString() {
     StringBuilder b = new StringBuilder();
     b.append(project);
     if (filter != null) {
       b.append("%filter=").append(filter);
+    }
+    if (problem != null) {
+      b.append("%problem=").append(problem);
     }
     b.append("(notifyAbandonedChanges=")
         .append(toBoolean(notifyAbandonedChanges))

--- a/src/main/java/com/google/gerrit/extensions/client/Side.java
+++ b/src/main/java/com/google/gerrit/extensions/client/Side.java
@@ -14,10 +14,13 @@
 
 package com.google.gerrit.extensions.client;
 
+import com.google.gerrit.common.Nullable;
+
 public enum Side {
   PARENT,
   REVISION;
 
+  @Nullable
   public static Side fromShort(short s) {
     if (s <= 0) {
       return PARENT;

--- a/src/main/java/com/google/gerrit/extensions/common/AbstractBatchInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/AbstractBatchInput.java
@@ -1,0 +1,26 @@
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.List;
+import java.util.Map;
+
+/** Input for the REST API that describes additions, updates and deletions items in a collection. */
+public abstract class AbstractBatchInput<T> {
+  public String commitMessage;
+  public List<String> delete;
+  public List<T> create;
+  public Map<String, T> update;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/AccountDetailInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/AccountDetailInfo.java
@@ -15,6 +15,7 @@
 package com.google.gerrit.extensions.common;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 
 /**
  * Representation of a (detailed) account in the REST API.
@@ -27,9 +28,18 @@ import java.sql.Timestamp;
  */
 public class AccountDetailInfo extends AccountInfo {
   /** The timestamp of when the account was registered. */
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp registeredOn;
 
   public AccountDetailInfo(Integer id) {
     super(id);
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public void setRegisteredOn(Instant registeredOn) {
+    this.registeredOn = Timestamp.from(registeredOn);
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/AccountExternalIdInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/AccountExternalIdInfo.java
@@ -57,10 +57,10 @@ public class AccountExternalIdInfo implements Comparable<AccountExternalIdInfo> 
   public boolean equals(Object o) {
     if (o instanceof AccountExternalIdInfo) {
       AccountExternalIdInfo a = (AccountExternalIdInfo) o;
-      return (Objects.equals(a.identity, identity))
-          && (Objects.equals(a.emailAddress, emailAddress))
-          && (Objects.equals(a.trusted, trusted))
-          && (Objects.equals(a.canDelete, canDelete));
+      return Objects.equals(a.identity, identity)
+          && Objects.equals(a.emailAddress, emailAddress)
+          && Objects.equals(a.trusted, trusted)
+          && Objects.equals(a.canDelete, canDelete);
     }
     return false;
   }

--- a/src/main/java/com/google/gerrit/extensions/common/AccountInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/AccountInfo.java
@@ -104,6 +104,7 @@ public class AccountInfo {
     other._moreAccounts = _moreAccounts;
     other.status = status;
     other.inactive = inactive;
+    other.deleted = deleted;
     other.tags = tags;
   }
 
@@ -121,6 +122,7 @@ public class AccountInfo {
           && Objects.equals(_moreAccounts, accountInfo._moreAccounts)
           && Objects.equals(status, accountInfo.status)
           && Objects.equals(inactive, accountInfo.inactive)
+          && Objects.equals(deleted, accountInfo.deleted)
           && Objects.equals(tags, accountInfo.tags);
     }
     return false;
@@ -152,6 +154,7 @@ public class AccountInfo {
         _moreAccounts,
         status,
         inactive,
+        deleted,
         tags);
   }
 

--- a/src/main/java/com/google/gerrit/extensions/common/AccountInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/AccountInfo.java
@@ -27,6 +27,15 @@ import java.util.Objects;
  * are defined in {@link AccountDetailInfo}.
  */
 public class AccountInfo {
+  /**
+   * Tags are additional properties of an account. These are just tags known to Gerrit core. Plugins
+   * may define their own.
+   */
+  public static final class Tags {
+    /** Tag indicating that this account is a service user. */
+    public static final String SERVICE_USER = "SERVICE_USER";
+  }
+
   /** The numeric ID of the account. */
   public Integer _accountId;
 
@@ -67,6 +76,12 @@ public class AccountInfo {
   /** Whether the account is inactive. */
   public Boolean inactive;
 
+  /** Whether the account is deleted. */
+  public Boolean deleted;
+
+  /** Tags, such as whether this account is a service user. */
+  public List<String> tags;
+
   public AccountInfo(Integer id) {
     this._accountId = id;
   }
@@ -75,6 +90,21 @@ public class AccountInfo {
   public AccountInfo(String name, String email) {
     this.name = name;
     this.email = email;
+  }
+
+  /** Copies properties of this AccountInfo to another instance. */
+  public void copyTo(AccountInfo other) {
+    other._accountId = _accountId;
+    other.name = name;
+    other.displayName = displayName;
+    other.email = email;
+    other.secondaryEmails = secondaryEmails;
+    other.username = username;
+    other.avatars = avatars;
+    other._moreAccounts = _moreAccounts;
+    other.status = status;
+    other.inactive = inactive;
+    other.tags = tags;
   }
 
   @Override
@@ -89,7 +119,9 @@ public class AccountInfo {
           && Objects.equals(username, accountInfo.username)
           && Objects.equals(avatars, accountInfo.avatars)
           && Objects.equals(_moreAccounts, accountInfo._moreAccounts)
-          && Objects.equals(status, accountInfo.status);
+          && Objects.equals(status, accountInfo.status)
+          && Objects.equals(inactive, accountInfo.inactive)
+          && Objects.equals(tags, accountInfo.tags);
     }
     return false;
   }
@@ -102,6 +134,8 @@ public class AccountInfo {
         .add("displayname", displayName)
         .add("email", email)
         .add("username", username)
+        .add("inactive", inactive)
+        .add("tags", tags)
         .toString();
   }
 
@@ -116,7 +150,9 @@ public class AccountInfo {
         username,
         avatars,
         _moreAccounts,
-        status);
+        status,
+        inactive,
+        tags);
   }
 
   protected AccountInfo() {}

--- a/src/main/java/com/google/gerrit/extensions/common/AccountStateInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/AccountStateInfo.java
@@ -1,0 +1,40 @@
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Representation of an account state in the REST API.
+ *
+ * <p>This class determines the JSON format of account states in the REST API.
+ */
+public class AccountStateInfo {
+  /** The account details. */
+  public AccountDetailInfo account;
+
+  /** The global capabilities of the account. */
+  public Map<String, Object> capabilities;
+
+  /** The groups that contain the account as a member. */
+  public List<GroupInfo> groups;
+
+  /** The external IDs of the account. */
+  public List<AccountExternalIdInfo> externalIds;
+
+  /** Account metadata populated by plugins. */
+  public List<MetadataInfo> metadata;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/ActionInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ActionInfo.java
@@ -15,6 +15,8 @@
 package com.google.gerrit.extensions.common;
 
 //import com.google.gerrit.extensions.webui.UiAction;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * Representation of an action in the REST API.
@@ -49,10 +51,49 @@ public class ActionInfo {
    */
   public Boolean enabled;
 
+  /**
+   * Optional list of enabled options.
+   *
+   * <p>For the {@code rebase} REST view the following options are supported:
+   *
+   * <ul>
+   *   <li>{@code rebase}: Present if the user can rebase the change. This is the case for the
+   *       change owner and users with the {@code Submit} or {@code Rebase} permission if they have
+   *       the {@code Push} permission.
+   *   <li>{@code rebase_on_behalf_of}: Present if the user can rebase the change on behalf of the
+   *       uploader. This is the case for the change owner and users with the {@code Submit} or
+   *       {@code Rebase} permission.
+   * </ul>
+   *
+   * <p>For all other REST views no options are returned.
+   */
+  public List<String> enabledOptions;
+
 //  public ActionInfo(UiAction.Description d) {
 //    method = d.getMethod();
 //    label = d.getLabel();
 //    title = d.getTitle();
 //    enabled = d.isEnabled() ? true : null;
+//    enabledOptions = d.getEnabledOptions();
 //  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof ActionInfo) {
+      ActionInfo actionInfo = (ActionInfo) o;
+      return Objects.equals(method, actionInfo.method)
+          && Objects.equals(label, actionInfo.label)
+          && Objects.equals(title, actionInfo.title)
+          && Objects.equals(enabled, actionInfo.enabled)
+          && Objects.equals(enabledOptions, actionInfo.enabledOptions);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(method, label, title, enabled, enabledOptions);
+  }
+
+  public ActionInfo() {}
 }

--- a/src/main/java/com/google/gerrit/extensions/common/ApplyProvidedFixInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ApplyProvidedFixInput.java
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,//
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.List;
+
+/**
+ * Input containing fix definitions to apply the provided fix to the change, on the patchset
+ * specified by revision id.
+ */
+public class ApplyProvidedFixInput {
+  public ApplyProvidedFixInput() {}
+
+  public List<FixReplacementInfo> fixReplacementInfos;
+
+  public Integer originalPatchsetForFix;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/ApprovalInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ApprovalInfo.java
@@ -16,6 +16,8 @@ package com.google.gerrit.extensions.common;
 
 import com.google.gerrit.common.Nullable;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Objects;
 
 /**
  * Representation of an approval in the REST API.
@@ -42,6 +44,8 @@ public class ApprovalInfo extends AccountInfo {
   public Integer value;
 
   /** The time and date describing when the approval was made. */
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp date;
 
   /** Whether this vote was made after the change was submitted. */
@@ -61,14 +65,60 @@ public class ApprovalInfo extends AccountInfo {
 
   public ApprovalInfo(
       Integer id,
-      Integer value,
+      @Nullable Integer value,
       @Nullable VotingRangeInfo permittedVotingRange,
       @Nullable String tag,
-      Timestamp date) {
+      @Nullable Timestamp date) {
     super(id);
     this.value = value;
     this.permittedVotingRange = permittedVotingRange;
     this.date = date;
     this.tag = tag;
+  }
+
+  public ApprovalInfo(
+      Integer id,
+      @Nullable Integer value,
+      @Nullable VotingRangeInfo permittedVotingRange,
+      @Nullable String tag,
+      @Nullable Instant date) {
+    super(id);
+    this.value = value;
+    this.permittedVotingRange = permittedVotingRange;
+    this.tag = tag;
+    if (date != null) {
+      setDate(date);
+    }
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public void setDate(Instant date) {
+    this.date = Timestamp.from(date);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof ApprovalInfo) {
+      ApprovalInfo approvalInfo = (ApprovalInfo) o;
+      return super.equals(o)
+          && Objects.equals(tag, approvalInfo.tag)
+          && Objects.equals(value, approvalInfo.value)
+          && Objects.equals(date, approvalInfo.date)
+          && Objects.equals(postSubmit, approvalInfo.postSubmit)
+          && Objects.equals(permittedVotingRange, approvalInfo.permittedVotingRange);
+    }
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return super.toString() + ", value=" + this.value;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), tag, value, date, postSubmit, permittedVotingRange);
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/AttentionSetInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/AttentionSetInfo.java
@@ -56,6 +56,15 @@ public class AttentionSetInfo {
     this.reasonAccount = reasonAccount;
   }
 
+  /**
+   * @deprecated removed upstream in favor of {@link #AttentionSetInfo(AccountInfo, Timestamp,
+   *     String, AccountInfo)}; kept for source/binary compatibility with existing callers.
+   */
+  @Deprecated
+  public AttentionSetInfo(AccountInfo account, Timestamp lastUpdate, String reason) {
+    this(account, lastUpdate, reason, null);
+  }
+
   // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
   // Instant
   @SuppressWarnings("JdkObsolete")

--- a/src/main/java/com/google/gerrit/extensions/common/AttentionSetInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/AttentionSetInfo.java
@@ -14,7 +14,10 @@
 
 package com.google.gerrit.extensions.common;
 
+import com.google.gerrit.common.Nullable;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Objects;
 
 /**
  * Represents a single user included in the attention set. Used in the API. See {@link
@@ -26,14 +29,60 @@ import java.sql.Timestamp;
 public class AttentionSetInfo {
   /** The user included in the attention set. */
   public AccountInfo account;
+
   /** The timestamp of the last update. */
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp lastUpdate;
+
   /** The human readable reason why the user was added. */
   public String reason;
 
-  public AttentionSetInfo(AccountInfo account, Timestamp lastUpdate, String reason) {
+  /**
+   * The user that might be mentioned in {@link #reason} as the one who caused the update. This is
+   * needed since {@link #reason} contains the account in pseudonymized form and is expanded in the
+   * frontend. {@code null} if there is no such account.
+   */
+  @Nullable public AccountInfo reasonAccount;
+
+  public AttentionSetInfo(
+      AccountInfo account,
+      Timestamp lastUpdate,
+      String reason,
+      @Nullable AccountInfo reasonAccount) {
     this.account = account;
     this.lastUpdate = lastUpdate;
     this.reason = reason;
+    this.reasonAccount = reasonAccount;
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public AttentionSetInfo(
+      AccountInfo account, Instant lastUpdate, String reason, @Nullable AccountInfo reasonAccount) {
+    this.account = account;
+    this.lastUpdate = Timestamp.from(lastUpdate);
+    this.reason = reason;
+    this.reasonAccount = reasonAccount;
+  }
+
+  protected AttentionSetInfo() {}
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof AttentionSetInfo) {
+      AttentionSetInfo attentionSetInfo = (AttentionSetInfo) o;
+      return Objects.equals(account, attentionSetInfo.account)
+          && Objects.equals(lastUpdate, attentionSetInfo.lastUpdate)
+          && Objects.equals(reason, attentionSetInfo.reason)
+          && Objects.equals(reasonAccount, attentionSetInfo.reasonAccount);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(account, lastUpdate, reason, reasonAccount);
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/AuthInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/AuthInfo.java
@@ -119,4 +119,11 @@ public class AuthInfo {
    * <p>Only set if authentication type is {@code LDAP}, {@code LDAP_BIND} or {@code OAUTH}.
    */
   public GitBasicAuthPolicy gitBasicAuthPolicy;
+
+  /**
+   * The maximum lifetime allowed for authentication tokens in minutes.
+   *
+   * <p>The value of the {@code auth.maxAuthTokenLifetime} parameter in {@code gerrit.config}.
+   */
+  public long maxTokenLifetime;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/AvatarInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/AvatarInfo.java
@@ -38,6 +38,9 @@ public class AvatarInfo {
   /** The height of the avatar image in pixels. */
   public Integer height;
 
+  /** @deprecated removed upstream. */
+  @Deprecated public Integer width;
+
   @Override
   public boolean equals(Object o) {
     if (o instanceof AvatarInfo) {

--- a/src/main/java/com/google/gerrit/extensions/common/AvatarInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/AvatarInfo.java
@@ -14,6 +14,8 @@
 
 package com.google.gerrit.extensions.common;
 
+import java.util.Objects;
+
 /**
  * Representation of an avatar in the REST API.
  *
@@ -36,6 +38,17 @@ public class AvatarInfo {
   /** The height of the avatar image in pixels. */
   public Integer height;
 
-  /** The width of the avatar image in pixels. */
-  public Integer width;
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof AvatarInfo) {
+      AvatarInfo avatarInfo = (AvatarInfo) o;
+      return Objects.equals(url, avatarInfo.url) && Objects.equals(height, avatarInfo.height);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(url, height);
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/BatchLabelInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/BatchLabelInput.java
@@ -14,13 +14,5 @@
 
 package com.google.gerrit.extensions.common;
 
-import java.util.List;
-import java.util.Map;
-
 /** Input for the REST API that describes additions, updates and deletions of label definitions. */
-public class BatchLabelInput {
-  public String commitMessage;
-  public List<String> delete;
-  public List<LabelDefinitionInput> create;
-  public Map<String, LabelDefinitionInput> update;
-}
+public class BatchLabelInput extends AbstractBatchInput<LabelDefinitionInput> {}

--- a/src/main/java/com/google/gerrit/extensions/common/BatchSubmitRequirementInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/BatchSubmitRequirementInput.java
@@ -1,0 +1,20 @@
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+/**
+ * Input for the REST API that describes additions, updates and deletions of submit requirements.
+ */
+public class BatchSubmitRequirementInput extends AbstractBatchInput<SubmitRequirementInput> {}

--- a/src/main/java/com/google/gerrit/extensions/common/BlameInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/BlameInfo.java
@@ -28,7 +28,7 @@ public class BlameInfo {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (o == null || !(o instanceof BlameInfo)) {
       return false;
     }
     BlameInfo blameInfo = (BlameInfo) o;

--- a/src/main/java/com/google/gerrit/extensions/common/CacheInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/CacheInfo.java
@@ -1,0 +1,85 @@
+// Copyright (C) 2021 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import com.google.gerrit.common.Nullable;
+
+public class CacheInfo {
+
+  public String name;
+  public CacheType type;
+  public EntriesInfo entries;
+  public String averageGet;
+  public HitRatioInfo hitRatio;
+
+  public static class EntriesInfo {
+    public Long mem;
+    public Long disk;
+    public String space;
+
+    public void setMem(long mem) {
+      this.mem = mem != 0 ? mem : null;
+    }
+
+    public void setDisk(long disk) {
+      this.disk = disk != 0 ? disk : null;
+    }
+
+    public void setSpace(double value) {
+      space = bytes(value);
+    }
+
+    public static String bytes(double value) {
+      value /= 1024;
+      String suffix = "k";
+
+      if (value > 1024) {
+        value /= 1024;
+        suffix = "m";
+      }
+      if (value > 1024) {
+        value /= 1024;
+        suffix = "g";
+      }
+      return String.format("%1$6.2f%2$s", value, suffix).trim();
+    }
+  }
+
+  public static class HitRatioInfo {
+    public Integer mem;
+    public Integer disk;
+
+    public void setMem(long value, long total) {
+      mem = percent(value, total);
+    }
+
+    public void setDisk(long value, long total) {
+      disk = percent(value, total);
+    }
+
+    @Nullable
+    private static Integer percent(long value, long total) {
+      if (total <= 0) {
+        return null;
+      }
+      return (int) ((100 * value) / total);
+    }
+  }
+
+  public enum CacheType {
+    MEM,
+    DISK
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/ChangeConfigInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ChangeConfigInfo.java
@@ -17,14 +17,31 @@ package com.google.gerrit.extensions.common;
 /** API response containing values from the {@code change} section of {@code gerrit.config}. */
 public class ChangeConfigInfo {
   public Boolean allowBlame;
-  public Boolean showAssigneeInChangesTable;
   public Boolean disablePrivateChanges;
-  public int largeChange;
-  public String replyLabel;
-  public String replyTooltip;
   public int updateDelay;
   public Boolean submitWholeTopic;
   public String mergeabilityComputationBehavior;
-  public Boolean enableAttentionSet;
-  public Boolean enableAssignee;
+  public Boolean conflictsPredicateEnabled;
+  public Boolean allowMarkdownBase64ImagesInComments;
+
+  // The fields below were removed from this class upstream. They are kept here, deprecated, for
+  // source/binary compatibility with existing callers.
+
+  /** @deprecated removed upstream along with the "assignee" feature (superseded by attention set). */
+  @Deprecated public Boolean showAssigneeInChangesTable;
+
+  /** @deprecated removed upstream. */
+  @Deprecated public int largeChange;
+
+  /** @deprecated removed upstream. */
+  @Deprecated public String replyLabel;
+
+  /** @deprecated removed upstream. */
+  @Deprecated public String replyTooltip;
+
+  /** @deprecated removed upstream (attention set is no longer an optional/toggleable feature). */
+  @Deprecated public Boolean enableAttentionSet;
+
+  /** @deprecated removed upstream along with the "assignee" feature (superseded by attention set). */
+  @Deprecated public Boolean enableAssignee;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/ChangeInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ChangeInfo.java
@@ -14,16 +14,21 @@
 
 package com.google.gerrit.extensions.common;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.gerrit.extensions.client.ChangeStatus;
 import com.google.gerrit.extensions.client.ReviewerState;
 import com.google.gerrit.extensions.client.SubmitType;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Representation of a change used in the API.
+ * Representation of a change used in the API. Internally {@link
+ * com.google.gerrit.server.query.change.ChangeData} and {@link com.google.gerrit.entities.Change}
+ * are used.
  *
  * <p>Many fields are actually nullable.
  */
@@ -32,23 +37,48 @@ public class ChangeInfo {
   // protected by any ListChangesOption.
 
   public String id;
+  public String tripletId;
+
   public String project;
+
+  /**
+   * The name of the target branch.
+   *
+   * <p>The {@code refs/heads/} prefix is omitted.
+   */
   public String branch;
+
+  /**
+   * The full name of the target branch.
+   *
+   * <p>Always starts with {@code refs/}.
+   */
+  public String fullBranch;
+
   public String topic;
+
   /**
    * The <a href="https://www.gerritcodereview.com/design-docs/attention-set.html">attention set</a>
-   * for this change. Keyed by account ID.
+   * for this change. Keyed by account ID. We don't use {@link
+   * com.google.gerrit.entities.Account.Id} to avoid a circular dependency.
    */
   public Map<Integer, AttentionSetInfo> attentionSet;
 
-  public AccountInfo assignee;
+  public Map<Integer, AttentionSetInfo> removedFromAttentionSet;
+
+  public Map<String, String> customKeyedValues;
+
   public Collection<String> hashtags;
   public String changeId;
   public String subject;
   public ChangeStatus status;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp created;
   public Timestamp updated;
   public Timestamp submitted;
+
   public AccountInfo submitter;
   public Boolean starred;
   public Collection<String> stars;
@@ -67,6 +97,7 @@ public class ChangeInfo {
   public String submissionId;
   public Integer cherryPickOfChange;
   public Integer cherryPickOfPatchSet;
+  public String metaRevId;
 
   /**
    * Whether the change contains conflicts.
@@ -75,30 +106,110 @@ public class ChangeInfo {
    * indicate the conflicts.
    *
    * <p>Only set if this change info is returned in response to a request that creates a new change
-   * or patch set and conflicts are allowed.
+   * or patch set and conflicts are allowed. In particular this field is only populated if the
+   * change info is returned by one of the following REST endpoints: {@link
+   * com.google.gerrit.server.restapi.change.ApplyPatch},{@link
+   * com.google.gerrit.server.restapi.change.CreateChange}, {@link
+   * com.google.gerrit.server.restapi.change.CreateMergePatchSet}, {@link
+   * com.google.gerrit.server.restapi.change.CherryPick}, {@link
+   * com.google.gerrit.server.restapi.change.CherryPickCommit}, {@link
+   * com.google.gerrit.server.restapi.change.Rebase}
    */
   public Boolean containsGitConflicts;
 
-  public int _number;
+  public Integer _number;
+  public Integer virtualIdNumber;
+
+  /** @deprecated removed upstream (server version &lt; 2.9, needed for change list paging). */
+  @Deprecated public String _sortkey;
+
+  /** @deprecated removed upstream along with the "assignee" feature (superseded by attention set). */
+  @Deprecated public AccountInfo assignee;
 
   public AccountInfo owner;
 
   public Map<String, ActionInfo> actions;
   public Map<String, LabelInfo> labels;
   public Map<String, Collection<String>> permittedLabels;
+  public Map<String, Map<String, List<AccountInfo>>> removableLabels;
   public Collection<AccountInfo> removableReviewers;
   public Map<ReviewerState, Collection<AccountInfo>> reviewers;
   public Map<ReviewerState, Collection<AccountInfo>> pendingReviewers;
   public Collection<ReviewerUpdateInfo> reviewerUpdates;
   public Collection<ChangeMessageInfo> messages;
 
+  public Integer currentRevisionNumber;
   public String currentRevision;
   public Map<String, RevisionInfo> revisions;
   public Boolean _moreChanges;
-  public String _sortkey; // server version < 2.9, needed for change list paging
 
   public List<ProblemInfo> problems;
   public List<PluginDefinedInfo> plugins;
   public Collection<TrackingIdInfo> trackingIds;
-  public Collection<SubmitRequirementInfo> requirements;
+  public Collection<LegacySubmitRequirementInfo> requirements;
+  public Collection<SubmitRecordInfo> submitRecords;
+  public Collection<SubmitRequirementResultInfo> submitRequirements;
+
+  public ChangeInfo() {}
+
+  public ChangeInfo(ChangeMessageInfo... messages) {
+    this.messages = ImmutableList.copyOf(messages);
+  }
+
+  public ChangeInfo(Map<String, RevisionInfo> revisions) {
+    this.revisions = ImmutableMap.copyOf(revisions);
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public Instant getCreated() {
+    return created.toInstant();
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public void setCreated(Instant when) {
+    created = Timestamp.from(when);
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public Instant getUpdated() {
+    return updated.toInstant();
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public void setUpdated(Instant when) {
+    updated = Timestamp.from(when);
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public Instant getSubmitted() {
+    return submitted.toInstant();
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public void setSubmitted(Instant when, AccountInfo who) {
+    submitted = Timestamp.from(when);
+    submitter = who;
+  }
+
+  public RevisionInfo getCurrentRevision() {
+    RevisionInfo currentRevisionInfo = revisions.get(currentRevision);
+    if (currentRevisionInfo.commit != null) {
+      // If all revisions are requested the commit.commit field is not populated because the commit
+      // SHA1 is already present as the key in the revisions map.
+      currentRevisionInfo.commit.commit = currentRevision;
+    }
+    return currentRevisionInfo;
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/ChangeInfoDifference.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ChangeInfoDifference.java
@@ -14,6 +14,10 @@
 
 package com.google.gerrit.extensions.common;
 
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+
 /** The difference between two {@link ChangeInfo}s returned by {@code ChangeInfoDiffer}. */
 public final class ChangeInfoDifference {
 
@@ -44,6 +48,40 @@ public final class ChangeInfoDifference {
 
   public ChangeInfo removed() {
     return removed;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ChangeInfoDifference)) {
+      return false;
+    }
+    ChangeInfoDifference that = (ChangeInfoDifference) o;
+    return Objects.equals(oldChangeInfo, that.oldChangeInfo)
+        && Objects.equals(newChangeInfo, that.newChangeInfo)
+        && Objects.equals(added, that.added)
+        && Objects.equals(removed, that.removed);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(oldChangeInfo, newChangeInfo, added, removed);
+  }
+
+  @Override
+  public String toString() {
+    return "ChangeInfoDifference{"
+        + "oldChangeInfo="
+        + oldChangeInfo
+        + ", newChangeInfo="
+        + newChangeInfo
+        + ", added="
+        + added
+        + ", removed="
+        + removed
+        + "}";
   }
 
   public static Builder builder() {
@@ -79,7 +117,11 @@ public final class ChangeInfoDifference {
     }
 
     public ChangeInfoDifference build() {
-      return new ChangeInfoDifference(oldChangeInfo, newChangeInfo, added, removed);
+      return new ChangeInfoDifference(
+          requireNonNull(oldChangeInfo, "oldChangeInfo"),
+          requireNonNull(newChangeInfo, "newChangeInfo"),
+          requireNonNull(added, "added"),
+          requireNonNull(removed, "removed"));
     }
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/ChangeInfoDifference.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ChangeInfoDifference.java
@@ -1,0 +1,85 @@
+// Copyright (C) 2021 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+/** The difference between two {@link ChangeInfo}s returned by {@code ChangeInfoDiffer}. */
+public final class ChangeInfoDifference {
+
+  private final ChangeInfo oldChangeInfo;
+  private final ChangeInfo newChangeInfo;
+  private final ChangeInfo added;
+  private final ChangeInfo removed;
+
+  private ChangeInfoDifference(
+      ChangeInfo oldChangeInfo, ChangeInfo newChangeInfo, ChangeInfo added, ChangeInfo removed) {
+    this.oldChangeInfo = oldChangeInfo;
+    this.newChangeInfo = newChangeInfo;
+    this.added = added;
+    this.removed = removed;
+  }
+
+  public ChangeInfo oldChangeInfo() {
+    return oldChangeInfo;
+  }
+
+  public ChangeInfo newChangeInfo() {
+    return newChangeInfo;
+  }
+
+  public ChangeInfo added() {
+    return added;
+  }
+
+  public ChangeInfo removed() {
+    return removed;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static final class Builder {
+    private ChangeInfo oldChangeInfo;
+    private ChangeInfo newChangeInfo;
+    private ChangeInfo added;
+    private ChangeInfo removed;
+
+    private Builder() {}
+
+    public Builder setOldChangeInfo(ChangeInfo oldChangeInfo) {
+      this.oldChangeInfo = oldChangeInfo;
+      return this;
+    }
+
+    public Builder setNewChangeInfo(ChangeInfo newChangeInfo) {
+      this.newChangeInfo = newChangeInfo;
+      return this;
+    }
+
+    public Builder setAdded(ChangeInfo added) {
+      this.added = added;
+      return this;
+    }
+
+    public Builder setRemoved(ChangeInfo removed) {
+      this.removed = removed;
+      return this;
+    }
+
+    public ChangeInfoDifference build() {
+      return new ChangeInfoDifference(oldChangeInfo, newChangeInfo, added, removed);
+    }
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/ChangeInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ChangeInput.java
@@ -14,11 +14,15 @@
 
 package com.google.gerrit.extensions.common;
 
+import com.google.gerrit.common.Nullable;
 import com.google.gerrit.extensions.api.accounts.AccountInput;
+import com.google.gerrit.extensions.api.changes.ApplyPatchInput;
 import com.google.gerrit.extensions.api.changes.NotifyHandling;
 import com.google.gerrit.extensions.api.changes.NotifyInfo;
 import com.google.gerrit.extensions.api.changes.RecipientType;
 import com.google.gerrit.extensions.client.ChangeStatus;
+import com.google.gerrit.extensions.client.ListChangesOption;
+import java.util.List;
 import java.util.Map;
 
 public class ChangeInput {
@@ -33,9 +37,14 @@ public class ChangeInput {
   public String baseChange;
   public String baseCommit;
   public Boolean newBranch;
+  public Map<String, String> validationOptions;
+  public Map<String, String> customKeyedValues;
   public MergeInput merge;
+  public ApplyPatchInput patch;
 
   public AccountInput author;
+
+  @Nullable public List<ListChangesOption> responseFormatOptions;
 
   public ChangeInput() {}
 
@@ -53,8 +62,12 @@ public class ChangeInput {
     this.subject = subject;
   }
 
-  /** Who to send email notifications to after change is created. */
-  public NotifyHandling notify = NotifyHandling.ALL;
+  /**
+   * Who to send email notifications to after change is created. If not specified, defaults to
+   * {@link NotifyHandling#OWNER} if the change is created as work-in-progress, or {@link
+   * NotifyHandling#ALL} otherwise.
+   */
+  public NotifyHandling notify;
 
   public Map<RecipientType, NotifyInfo> notifyDetails;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/ChangeMessageInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ChangeMessageInfo.java
@@ -14,17 +14,39 @@
 
 package com.google.gerrit.extensions.common;
 
+import com.google.common.collect.Iterables;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Collection;
 import java.util.Objects;
 
+/** Represent {@link com.google.gerrit.entities.ChangeMessage} in the REST API. */
 public class ChangeMessageInfo {
   public String id;
   public String tag;
   public AccountInfo author;
   public AccountInfo realAuthor;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp date;
+
   public String message;
+  public Collection<AccountInfo> accountsInMessage;
   public Integer _revisionNumber;
+
+  public ChangeMessageInfo() {}
+
+  public ChangeMessageInfo(String message) {
+    this.message = message;
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public void setDate(Instant when) {
+    date = Timestamp.from(when);
+  }
 
   @Override
   public boolean equals(Object o) {
@@ -36,6 +58,10 @@ public class ChangeMessageInfo {
           && Objects.equals(realAuthor, cmi.realAuthor)
           && Objects.equals(date, cmi.date)
           && Objects.equals(message, cmi.message)
+          && ((accountsInMessage == null && cmi.accountsInMessage == null)
+              || (accountsInMessage != null
+                  && cmi.accountsInMessage != null
+                  && Iterables.elementsEqual(accountsInMessage, cmi.accountsInMessage)))
           && Objects.equals(_revisionNumber, cmi._revisionNumber);
     }
     return false;
@@ -43,7 +69,8 @@ public class ChangeMessageInfo {
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, tag, author, realAuthor, date, message, _revisionNumber);
+    return Objects.hash(
+        id, tag, author, realAuthor, date, message, accountsInMessage, _revisionNumber);
   }
 
   @Override
@@ -63,6 +90,8 @@ public class ChangeMessageInfo {
         + _revisionNumber
         + ", message=["
         + message
-        + "]}";
+        + "], accountsForTemplate="
+        + accountsInMessage
+        + "}";
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/ChangeMessageInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ChangeMessageInfo.java
@@ -70,7 +70,28 @@ public class ChangeMessageInfo {
   @Override
   public int hashCode() {
     return Objects.hash(
-        id, tag, author, realAuthor, date, message, accountsInMessage, _revisionNumber);
+        id,
+        tag,
+        author,
+        realAuthor,
+        date,
+        message,
+        accountsInMessageHashCode(),
+        _revisionNumber);
+  }
+
+  // accountsInMessage is compared via Iterables.elementsEqual (order-sensitive, but agnostic to
+  // the concrete Collection implementation), so its hash must be derived the same way instead of
+  // delegating to the collection's own hashCode(), which is implementation-dependent.
+  private int accountsInMessageHashCode() {
+    if (accountsInMessage == null) {
+      return 0;
+    }
+    int hash = 1;
+    for (AccountInfo accountInfo : accountsInMessage) {
+      hash = 31 * hash + Objects.hashCode(accountInfo);
+    }
+    return hash;
   }
 
   @Override

--- a/src/main/java/com/google/gerrit/extensions/common/CommentInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/CommentInfo.java
@@ -15,24 +15,38 @@
 package com.google.gerrit.extensions.common;
 
 import com.google.gerrit.extensions.client.Comment;
+import java.util.List;
 import java.util.Objects;
 
 public class CommentInfo extends Comment {
   public AccountInfo author;
   public String tag;
   public String changeMessageId;
+  public Boolean unresolved;
+
+  /**
+   * A list of {@link ContextLineInfo}, that is, a list of pairs of {line_num, line_text} of the
+   * actual source file content surrounding and including the lines where the comment was written.
+   */
+  public List<ContextLineInfo> contextLines;
+
+  /** Mime type of the underlying source file. Only available if context lines are requested. */
+  public String sourceContentType;
 
   @Override
   public boolean equals(Object o) {
     if (super.equals(o)) {
       CommentInfo ci = (CommentInfo) o;
-      return Objects.equals(author, ci.author) && Objects.equals(tag, ci.tag);
+      return Objects.equals(author, ci.author)
+          && Objects.equals(tag, ci.tag)
+          && Objects.equals(unresolved, ci.unresolved)
+          && Objects.equals(fixSuggestions, ci.fixSuggestions);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), author, tag);
+    return Objects.hash(super.hashCode(), author, tag, unresolved, fixSuggestions);
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/CommentInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/CommentInfo.java
@@ -22,7 +22,6 @@ public class CommentInfo extends Comment {
   public AccountInfo author;
   public String tag;
   public String changeMessageId;
-  public Boolean unresolved;
 
   /**
    * A list of {@link ContextLineInfo}, that is, a list of pairs of {line_num, line_text} of the

--- a/src/main/java/com/google/gerrit/extensions/common/CommitInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/CommitInfo.java
@@ -29,6 +29,7 @@ public class CommitInfo {
   public String subject;
   public String message;
   public List<WebLinkInfo> webLinks;
+  public List<WebLinkInfo> resolveConflictsWebLinks;
 
   @Override
   public boolean equals(Object o) {
@@ -42,12 +43,14 @@ public class CommitInfo {
         && Objects.equals(committer, c.committer)
         && Objects.equals(subject, c.subject)
         && Objects.equals(message, c.message)
-        && Objects.equals(webLinks, c.webLinks);
+        && Objects.equals(webLinks, c.webLinks)
+        && Objects.equals(resolveConflictsWebLinks, c.resolveConflictsWebLinks);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(commit, parents, author, committer, subject, message, webLinks);
+    return Objects.hash(
+        commit, parents, author, committer, subject, message, webLinks, resolveConflictsWebLinks);
   }
 
   @Override
@@ -63,6 +66,9 @@ public class CommitInfo {
         .add("message", message);
     if (webLinks != null) {
       helper.add("webLinks", webLinks);
+    }
+    if (resolveConflictsWebLinks != null) {
+      helper.add("resolveConflictsWebLinks", resolveConflictsWebLinks);
     }
     return helper.toString();
   }

--- a/src/main/java/com/google/gerrit/extensions/common/CommitMessageInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/CommitMessageInfo.java
@@ -1,0 +1,37 @@
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.Map;
+
+/** Representation of a commit message used in the API. */
+public class CommitMessageInfo {
+  /**
+   * The subject of the change.
+   *
+   * <p>First line of the commit message.
+   */
+  public String subject;
+
+  /** Full commit message of the change. */
+  public String fullMessage;
+
+  /**
+   * The footers from the commit message.
+   *
+   * <p>Key-value pairs from the last paragraph of the commit message.
+   */
+  public Map<String, String> footers;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/CommitMessageInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/CommitMessageInput.java
@@ -27,4 +27,6 @@ public class CommitMessageInput {
   @Nullable public NotifyHandling notify;
 
   public Map<RecipientType, NotifyInfo> notifyDetails;
+
+  public String committerEmail;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/ConflictsInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ConflictsInfo.java
@@ -1,0 +1,107 @@
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+/** Information about conflicts in a revision. */
+public class ConflictsInfo {
+  /**
+   * The SHA1 of the commit that was used as the base commit for the Git merge that created the
+   * revision.
+   *
+   * <p>A base is not set if:
+   *
+   * <ul>
+   *   <li>the merged commits do not have a common ancestor (in this case {@link #noBaseReason} is
+   *       {@link NoMergeBaseReason#NO_COMMON_ANCESTOR}).
+   *   <li>the merged commits have multiple merge bases (happens for criss-cross-merges) and the
+   *       base was computed (in this case {@link #noBaseReason} is {@link
+   *       NoMergeBaseReason#COMPUTED_BASE}).
+   *   <li>a one sided merge strategy (e.g. {@code ours} or {@code theirs}) has been used and
+   *       computing a base was not required for the merge (in this case {@link #noBaseReason} is
+   *       {@link NoMergeBaseReason#ONE_SIDED_MERGE_STRATEGY}).
+   *   <li>the revision was not created by performing a Git merge operation (in this case {@link
+   *       #noBaseReason} is {@link NoMergeBaseReason#NO_MERGE_PERFORMED}).
+   *   <li>the revision has been created before Gerrit started to store the base for conflicts (in
+   *       this case {@link #noBaseReason} is {@link NoMergeBaseReason#HISTORIC_DATA_WITHOUT_BASE}).
+   * </ul>
+   */
+  public String base;
+
+  /**
+   * The SHA1 of the commit that was used as {@code ours} for the Git merge that created the
+   * revision.
+   *
+   * <p>Guaranteed to be set if {@link #containsConflicts} is {@code true}. If {@link
+   * #containsConflicts} is {@code false}, only set if the revision was created by Gerrit as a
+   * result of performing a Git merge.
+   */
+  public String ours;
+
+  /**
+   * The SHA1 of the commit that was used as {@code theirs} for the Git merge that created the
+   * revision.
+   *
+   * <p>Guaranteed to be set if {@link #containsConflicts} is {@code true}. If {@link
+   * #containsConflicts} is {@code false}, only set if the revision was created by Gerrit as a
+   * result of performing a Git merge.
+   */
+  public String theirs;
+
+  /**
+   * The merge strategy was used for the Git merge that created the revision.
+   *
+   * <p>Possible values: {@code resolve}, {@code recursive}, {@code simple-two-way-in-core}, {@code
+   * ours} and {@code theirs}.
+   */
+  public String mergeStrategy;
+
+  /**
+   * Reason why {@link #base} is not set.
+   *
+   * <p>Only set if {@link #base} is not set.
+   *
+   * <p>Possible values are:
+   *
+   * <ul>
+   *   <li>{@code NO_COMMON_ANCESTOR}: The merged commits do not have a common ancestor.
+   *   <li>{@code COMPUTED_BASE}: The merged commits have multiple merge bases (happens for
+   *       criss-cross-merges) and the base was computed.
+   *   <li>{@code ONE_SIDED_MERGE_STRATEGY}: A one sided merge strategy (e.g. {@code ours} or {@code
+   *       theirs}) has been used and computing a base was not required for the merge.
+   *   <li>{@code NO_MERGE_PERFORMED}: The revision was not created by performing a Git merge
+   *       operation.
+   *   <li>{@code HISTORIC_DATA_WITHOUT_BASE}: The revision has been created before Gerrit started
+   *       to store the base for conflicts.
+   * </ul>
+   */
+  public NoMergeBaseReason noBaseReason;
+
+  /**
+   * Whether any of the files in the revision has a conflict due to merging {@link #ours} and {@link
+   * #theirs}.
+   *
+   * <p>If {@code true} at least one of the files in the revision has a conflict and contains Git
+   * conflict markers. The conflicts occurred while performing a merge between {@link #ours} and
+   * {@link #theirs}.
+   *
+   * <p>If {@code false}, and {@link #ours} and {@link #theirs} are present, merging {@link #ours}
+   * and {@link #theirs} didn't have any conflict. In this case the files in the revision may only
+   * contain Git conflict markers if they were already present in {@link #ours} or {@link #theirs}.
+   *
+   * <p>If {@code false}, and {@link #ours} and {@link #theirs} are not present, the revision was
+   * not created as a result of performing a Git merge and hence doesn't contain conflicts.
+   */
+  public Boolean containsConflicts;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/ContextLineInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ContextLineInfo.java
@@ -1,0 +1,47 @@
+// Copyright (C) 2020 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.Objects;
+
+/**
+ * An entity class representing 1 line of context {line number, line text} of the source file where
+ * a comment was written.
+ */
+public class ContextLineInfo {
+  public int lineNumber;
+  public String contextLine;
+
+  public ContextLineInfo() {}
+
+  public ContextLineInfo(int lineNumber, String contextLine) {
+    this.lineNumber = lineNumber;
+    this.contextLine = contextLine;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof ContextLineInfo) {
+      ContextLineInfo l = (ContextLineInfo) o;
+      return lineNumber == l.lineNumber && contextLine.equals(l.contextLine);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(lineNumber, contextLine);
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/DiffInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/DiffInfo.java
@@ -32,6 +32,8 @@ public class DiffInfo {
   public List<ContentEntry> content;
   // Links to the file diff in external sites
   public List<DiffWebLinkInfo> webLinks;
+  // Links to edit the file in external sites
+  public List<WebLinkInfo> editWebLinks;
   // Binary file
   public Boolean binary;
 

--- a/src/main/java/com/google/gerrit/extensions/common/DiffWebLinkInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/DiffWebLinkInfo.java
@@ -18,29 +18,26 @@ public class DiffWebLinkInfo extends WebLinkInfo {
   public Boolean showOnSideBySideDiffView;
   public Boolean showOnUnifiedDiffView;
 
-  public static DiffWebLinkInfo forSideBySideDiffView(
-      String name, String imageUrl, String url, String target) {
-    return new DiffWebLinkInfo(name, imageUrl, url, target, true, false);
+  public static DiffWebLinkInfo forSideBySideDiffView(String name, String imageUrl, String url) {
+    return new DiffWebLinkInfo(name, imageUrl, url, true, false);
   }
 
-  public static DiffWebLinkInfo forUnifiedDiffView(
-      String name, String imageUrl, String url, String target) {
-    return new DiffWebLinkInfo(name, imageUrl, url, target, false, true);
+  public static DiffWebLinkInfo forUnifiedDiffView(String name, String imageUrl, String url) {
+    return new DiffWebLinkInfo(name, imageUrl, url, false, true);
   }
 
   public static DiffWebLinkInfo forSideBySideAndUnifiedDiffView(
-      String name, String imageUrl, String url, String target) {
-    return new DiffWebLinkInfo(name, imageUrl, url, target, true, true);
+      String name, String imageUrl, String url) {
+    return new DiffWebLinkInfo(name, imageUrl, url, true, true);
   }
 
   private DiffWebLinkInfo(
       String name,
       String imageUrl,
       String url,
-      String target,
       boolean showOnSideBySideDiffView,
       boolean showOnUnifiedDiffView) {
-    super(name, imageUrl, url, target);
+    super(name, imageUrl, url);
     this.showOnSideBySideDiffView = showOnSideBySideDiffView ? true : null;
     this.showOnUnifiedDiffView = showOnUnifiedDiffView ? true : null;
   }

--- a/src/main/java/com/google/gerrit/extensions/common/DiffWebLinkInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/DiffWebLinkInfo.java
@@ -22,13 +22,40 @@ public class DiffWebLinkInfo extends WebLinkInfo {
     return new DiffWebLinkInfo(name, imageUrl, url, true, false);
   }
 
+  /** @deprecated removed upstream; kept for source/binary compatibility with existing callers. */
+  @Deprecated
+  public static DiffWebLinkInfo forSideBySideDiffView(
+      String name, String imageUrl, String url, String target) {
+    DiffWebLinkInfo info = forSideBySideDiffView(name, imageUrl, url);
+    info.target = target;
+    return info;
+  }
+
   public static DiffWebLinkInfo forUnifiedDiffView(String name, String imageUrl, String url) {
     return new DiffWebLinkInfo(name, imageUrl, url, false, true);
+  }
+
+  /** @deprecated removed upstream; kept for source/binary compatibility with existing callers. */
+  @Deprecated
+  public static DiffWebLinkInfo forUnifiedDiffView(
+      String name, String imageUrl, String url, String target) {
+    DiffWebLinkInfo info = forUnifiedDiffView(name, imageUrl, url);
+    info.target = target;
+    return info;
   }
 
   public static DiffWebLinkInfo forSideBySideAndUnifiedDiffView(
       String name, String imageUrl, String url) {
     return new DiffWebLinkInfo(name, imageUrl, url, true, true);
+  }
+
+  /** @deprecated removed upstream; kept for source/binary compatibility with existing callers. */
+  @Deprecated
+  public static DiffWebLinkInfo forSideBySideAndUnifiedDiffView(
+      String name, String imageUrl, String url, String target) {
+    DiffWebLinkInfo info = forSideBySideAndUnifiedDiffView(name, imageUrl, url);
+    info.target = target;
+    return info;
   }
 
   private DiffWebLinkInfo(

--- a/src/main/java/com/google/gerrit/extensions/common/DownloadSchemeInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/DownloadSchemeInfo.java
@@ -18,6 +18,7 @@ import java.util.Map;
 
 public class DownloadSchemeInfo {
   public String url;
+  public String description;
   public Boolean isAuthRequired;
   public Boolean isAuthSupported;
   public Map<String, String> commands;

--- a/src/main/java/com/google/gerrit/extensions/common/EditInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/EditInfo.java
@@ -23,4 +23,16 @@ public class EditInfo {
   public String ref;
   public Map<String, FetchInfo> fetch;
   public Map<String, FileInfo> files;
+
+  /**
+   * Whether the change edit contains conflicts.
+   *
+   * <p>If {@code true}, some of the file contents of the change contain git conflict markers to
+   * indicate the conflicts.
+   *
+   * <p>Only set if this edit info is returned in response to a request that rebases the change edit
+   * (see {@link com.google.gerrit.server.restapi.change.RebaseChangeEdit}) and conflicts are
+   * allowed.
+   */
+  public Boolean containsGitConflicts;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/EmailInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/EmailInfo.java
@@ -17,9 +17,14 @@ package com.google.gerrit.extensions.common;
 public class EmailInfo {
   public String email;
   public Boolean preferred;
+  public Boolean avatar;
   public Boolean pendingConfirmation;
 
   public void preferred(String e) {
-    this.preferred = e != null && e.equals(email) ? true : null;
+    this.preferred = (e != null && e.equals(email)) ? true : null;
+  }
+
+  public void avatar(String e) {
+    this.avatar = (e != null && e.equals(email)) ? true : null;
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/EvaluateChangeQueryExpressionResultInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/EvaluateChangeQueryExpressionResultInfo.java
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import com.google.gerrit.common.Nullable;
+import java.util.List;
+import java.util.Map;
+
+/** Result of evaluating a change query expression. */
+public class EvaluateChangeQueryExpressionResultInfo {
+  /** Whether the change matches the change query expression. */
+  public boolean status;
+
+  /** List of passing leaf atoms (atoms that match the change). */
+  public List<String> passingAtoms;
+
+  /** List of failing leaf atoms (atoms that do not match the change). */
+  public List<String> failingAtoms;
+
+  /**
+   * Explanations for why atoms pass or fail.
+   *
+   * <p>Explanations are only available for a few atoms, for most atoms no explanation is provided.
+   *
+   * <p>Not set if none of the atoms has an explanation.
+   */
+  @Nullable public Map<String, String> atomExplanations;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/ExperimentInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ExperimentInfo.java
@@ -1,0 +1,20 @@
+// Copyright (C) 2034 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+public class ExperimentInfo {
+  /** Whether the experiment is enabled. */
+  public Boolean enabled;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/FetchInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FetchInfo.java
@@ -15,6 +15,7 @@
 package com.google.gerrit.extensions.common;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class FetchInfo {
   public String url;
@@ -25,4 +26,22 @@ public class FetchInfo {
     this.url = url;
     this.ref = ref;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof FetchInfo) {
+      FetchInfo fetchInfo = (FetchInfo) o;
+      return Objects.equals(url, fetchInfo.url)
+          && Objects.equals(ref, fetchInfo.ref)
+          && Objects.equals(commands, fetchInfo.commands);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(url, ref, commands);
+  }
+
+  protected FetchInfo() {}
 }

--- a/src/main/java/com/google/gerrit/extensions/common/FileInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FileInfo.java
@@ -18,6 +18,10 @@ import java.util.Objects;
 
 public class FileInfo {
   public Character status;
+  public Integer oldMode;
+  public Integer newMode;
+  public String oldSha;
+  public String newSha;
   public Boolean binary;
   public String oldPath;
   public Integer linesInserted;
@@ -25,23 +29,72 @@ public class FileInfo {
   public long sizeDelta;
   public long size;
 
+  /**
+   * Returns {@code true} if the diff computation was not able to compute a diff, i.e. for diffs
+   * taking a very long time to compute.
+   */
+  public Boolean diffsTooExpensiveToCompute;
+
   @Override
   public boolean equals(Object o) {
     if (o instanceof FileInfo) {
       FileInfo fileInfo = (FileInfo) o;
       return Objects.equals(status, fileInfo.status)
+          && Objects.equals(oldMode, fileInfo.oldMode)
+          && Objects.equals(newMode, fileInfo.newMode)
+          && Objects.equals(oldSha, fileInfo.oldSha)
+          && Objects.equals(newSha, fileInfo.newSha)
           && Objects.equals(binary, fileInfo.binary)
           && Objects.equals(oldPath, fileInfo.oldPath)
           && Objects.equals(linesInserted, fileInfo.linesInserted)
           && Objects.equals(linesDeleted, fileInfo.linesDeleted)
-          && Objects.equals(sizeDelta, fileInfo.sizeDelta)
-          && Objects.equals(size, fileInfo.size);
+          && sizeDelta == fileInfo.sizeDelta
+          && size == fileInfo.size
+          && Objects.equals(diffsTooExpensiveToCompute, fileInfo.diffsTooExpensiveToCompute);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(status, binary, oldPath, linesInserted, linesDeleted, sizeDelta, size);
+    return Objects.hash(
+        status,
+        binary,
+        oldPath,
+        linesInserted,
+        linesDeleted,
+        sizeDelta,
+        size,
+        diffsTooExpensiveToCompute);
+  }
+
+  @Override
+  public String toString() {
+    return "FileInfo{"
+        + "status="
+        + status
+        + ", oldMode="
+        + oldMode
+        + ", newMode="
+        + oldMode
+        + ", oldSha="
+        + oldSha
+        + ", newSha="
+        + oldSha
+        + ", binary="
+        + binary
+        + ", oldPath="
+        + oldPath
+        + ", linesInserted="
+        + linesInserted
+        + ", linesDeleted="
+        + linesDeleted
+        + ", sizeDelta="
+        + sizeDelta
+        + ", size="
+        + size
+        + ", diffsTooExpensiveToCompute="
+        + diffsTooExpensiveToCompute
+        + "}";
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/FileInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FileInfo.java
@@ -76,11 +76,11 @@ public class FileInfo {
         + ", oldMode="
         + oldMode
         + ", newMode="
-        + oldMode
+        + newMode
         + ", oldSha="
         + oldSha
         + ", newSha="
-        + oldSha
+        + newSha
         + ", binary="
         + binary
         + ", oldPath="

--- a/src/main/java/com/google/gerrit/extensions/common/FixReplacementInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FixReplacementInfo.java
@@ -15,9 +15,26 @@
 package com.google.gerrit.extensions.common;
 
 import com.google.gerrit.extensions.client.Comment;
+import java.util.Objects;
 
 public class FixReplacementInfo {
   public String path;
   public Comment.Range range;
   public String replacement;
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof FixReplacementInfo)) {
+      return false;
+    }
+    FixReplacementInfo fs = (FixReplacementInfo) o;
+    return Objects.equals(path, fs.path)
+        && Objects.equals(range, fs.range)
+        && Objects.equals(replacement, fs.replacement);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(path, range, replacement);
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/FixSuggestionInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FixSuggestionInfo.java
@@ -15,9 +15,26 @@
 package com.google.gerrit.extensions.common;
 
 import java.util.List;
+import java.util.Objects;
 
 public class FixSuggestionInfo {
   public String fixId;
   public String description;
   public List<FixReplacementInfo> replacements;
+
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof FixSuggestionInfo)) {
+      return false;
+    }
+    FixSuggestionInfo fs = (FixSuggestionInfo) o;
+    return Objects.equals(fixId, fs.fixId)
+        && Objects.equals(description, fs.description)
+        && Objects.equals(replacements, fs.replacements);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(fixId, description, replacements);
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/FlowActionInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FlowActionInfo.java
@@ -1,0 +1,40 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.List;
+
+/**
+ * Representation of a flow action in the REST API.
+ *
+ * <p>This class determines the JSON format of flow actions in the REST API.
+ *
+ * <p>An action to be triggered when the condition of a flow expression becomes satisfied.
+ */
+public class FlowActionInfo {
+  /**
+   * The name of the action.
+   *
+   * <p>Which actions are supported depends on the flow service implementation.
+   */
+  public String name;
+
+  /**
+   * Parameters for the action.
+   *
+   * <p>Which parameters are supported depends on the flow service implementation.
+   */
+  public List<String> parameters;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/FlowActionTypeInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FlowActionTypeInfo.java
@@ -1,0 +1,34 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+/**
+ * Representation of a flow action type in the REST API.
+ *
+ * <p>This class determines the JSON format of flow action types in the REST API.
+ *
+ * <p>An action type to be triggered when the condition of a flow expression becomes satisfied.
+ */
+public class FlowActionTypeInfo {
+  /**
+   * The name of the action type.
+   *
+   * <p>Which action types are supported depends on the flow service implementation.
+   */
+  public String name;
+
+  /** The parameters placeholder text to display in the UI. */
+  public String parametersPlaceholder;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/FlowExpressionInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FlowExpressionInfo.java
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import com.google.gerrit.common.Nullable;
+
+/**
+ * Representation of a flow expression in the REST API.
+ *
+ * <p>This class determines the JSON format of flow expressions in the REST API.
+ *
+ * <p>A stage flow expression defines an action that should be triggered when a condition becomes
+ * satisfied.
+ */
+public class FlowExpressionInfo {
+  /**
+   * The condition which must be satisfied for the action to be triggered.
+   *
+   * <p>Can contain multiple conditions separated by comma.
+   *
+   * <p>The syntax of the condition depends on the flow service implementation.
+   */
+  public String condition;
+
+  /**
+   * The action that should be triggered when the condition is satisfied.
+   *
+   * <p>If null, no action is performed.
+   */
+  @Nullable public FlowActionInfo action;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/FlowInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FlowInfo.java
@@ -1,0 +1,61 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Representation of a flow in the REST API.
+ *
+ * <p>This class determines the JSON format of flows in the REST API.
+ *
+ * <p>A flow is an automation rule on a change that triggers actions on the change when the flow
+ * conditions become satisfied.
+ */
+public class FlowInfo {
+  /** The universally unique identifier that identifies the flow. */
+  public String uuid;
+
+  /** The owner of the flow as an {@link AccountInfo} entity. */
+  public AccountInfo owner;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+
+  /** The timestamp of when the flow was created. */
+  public Timestamp created;
+
+  @SuppressWarnings("JdkObsolete")
+  public void setCreated(Instant when) {
+    created = Timestamp.from(when);
+  }
+
+  /** The stages of this flow (sorted by execution order). */
+  public List<FlowStageInfo> stages;
+
+  /**
+   * The timestamp of when the flow was last evaluated.
+   *
+   * <p>Not set if the flow has not been evaluated yet.
+   */
+  public Timestamp lastEvaluated;
+
+  @SuppressWarnings("JdkObsolete")
+  public void setLastEvaluated(Instant when) {
+    lastEvaluated = Timestamp.from(when);
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/FlowInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FlowInput.java
@@ -1,0 +1,30 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.List;
+
+/**
+ * REST API input for creating a flow.
+ *
+ * <p>This class determines the JSON format of flow inputs in the REST API.
+ *
+ * <p>Clients send a flow input in the request body when calling {@code POST
+ * /change/<change-id>/flows}.
+ */
+public class FlowInput {
+  /** The expressions for the stages of the flow (sorted by execution order). */
+  public List<FlowExpressionInfo> stageExpressions;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/FlowStageInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FlowStageInfo.java
@@ -1,0 +1,38 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+/**
+ * Representation of a stage in a flow in the REST API.
+ *
+ * <p>This class determines the JSON format of stages in flows in the REST API.
+ *
+ * <p>A stage in a flow consists out of a flow expression that defines an action that should be
+ * triggered when a condition becomes satisfied and a status.
+ */
+public class FlowStageInfo {
+  /** The expression defining the condition and the action of this stage. */
+  public FlowExpressionInfo expression;
+
+  /** The state for this stage. */
+  public FlowStageState state;
+
+  /**
+   * Optional message for the stage.
+   *
+   * <p>May be unset.
+   */
+  public String message;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/FlowStageState.java
+++ b/src/main/java/com/google/gerrit/extensions/common/FlowStageState.java
@@ -1,0 +1,33 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+/** State of a stage in a flow in the REST API. */
+public enum FlowStageState {
+  /** The condition of the stage is not satisfied yet or the action has not been executed yet. */
+  PENDING,
+
+  /** The condition of the stage is satisfied and the action has been executed. */
+  DONE,
+
+  /** The stage has a non-recoverable error, e.g. performing the action has failed. */
+  FAILED,
+
+  /**
+   * The stage has been terminated without having been executed, e.g. because a previous stage
+   * failed or because it wasn't done within a timeout.
+   */
+  TERMINATED;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/GerritInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/GerritInfo.java
@@ -23,4 +23,7 @@ public class GerritInfo {
   public Boolean editGpgKeys;
   public String reportBugUrl;
   public String primaryWeblinkName;
+  public String instanceId;
+  public String defaultBranch;
+  public Boolean projectStatePredicateEnabled;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/GitPerson.java
+++ b/src/main/java/com/google/gerrit/extensions/common/GitPerson.java
@@ -15,13 +15,25 @@
 package com.google.gerrit.extensions.common;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Objects;
 
 public class GitPerson {
   public String name;
   public String email;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp date;
+
   public int tz;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public void setDate(Instant when) {
+    date = Timestamp.from(when);
+  }
 
   @Override
   public boolean equals(Object o) {

--- a/src/main/java/com/google/gerrit/extensions/common/GpgKeyInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/GpgKeyInfo.java
@@ -15,6 +15,7 @@
 package com.google.gerrit.extensions.common;
 
 import java.util.List;
+import java.util.Objects;
 
 public class GpgKeyInfo {
   /**
@@ -43,4 +44,22 @@ public class GpgKeyInfo {
 
   public Status status;
   public List<String> problems;
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof GpgKeyInfo) {
+      GpgKeyInfo gpgKeyInfo = (GpgKeyInfo) o;
+      return Objects.equals(id, gpgKeyInfo.id)
+          && Objects.equals(fingerprint, gpgKeyInfo.fingerprint)
+          && Objects.equals(userIds, gpgKeyInfo.userIds)
+          && Objects.equals(status, gpgKeyInfo.status)
+          && Objects.equals(problems, gpgKeyInfo.problems);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, fingerprint, userIds, status, problems);
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/GroupAuditEventInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/GroupAuditEventInfo.java
@@ -14,7 +14,9 @@
 
 package com.google.gerrit.extensions.common;
 
+import com.google.gerrit.common.Nullable;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Optional;
 
 public abstract class GroupAuditEventInfo {
@@ -27,25 +29,62 @@ public abstract class GroupAuditEventInfo {
 
   public Type type;
   public AccountInfo user;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp date;
 
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
   public static UserMemberAuditEventInfo createAddUserEvent(
       AccountInfo user, Timestamp date, AccountInfo member) {
-    return new UserMemberAuditEventInfo(Type.ADD_USER, user, Optional.of(date), member);
+    return new UserMemberAuditEventInfo(Type.ADD_USER, user, date.toInstant(), member);
+  }
+
+  public static UserMemberAuditEventInfo createAddUserEvent(
+      AccountInfo user, Instant date, AccountInfo member) {
+    return new UserMemberAuditEventInfo(Type.ADD_USER, user, date, member);
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public static UserMemberAuditEventInfo createRemoveUserEvent(
+      AccountInfo user, Optional<Timestamp> date, AccountInfo member) {
+    return new UserMemberAuditEventInfo(
+        Type.REMOVE_USER, user, date.map(Timestamp::toInstant).orElse(null), member);
   }
 
   public static UserMemberAuditEventInfo createRemoveUserEvent(
-      AccountInfo user, Optional<Timestamp> date, AccountInfo member) {
+      AccountInfo user, @Nullable Instant date, AccountInfo member) {
     return new UserMemberAuditEventInfo(Type.REMOVE_USER, user, date, member);
   }
 
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
   public static GroupMemberAuditEventInfo createAddGroupEvent(
       AccountInfo user, Timestamp date, GroupInfo member) {
-    return new GroupMemberAuditEventInfo(Type.ADD_GROUP, user, Optional.of(date), member);
+    return new GroupMemberAuditEventInfo(Type.ADD_GROUP, user, date.toInstant(), member);
+  }
+
+  public static GroupMemberAuditEventInfo createAddGroupEvent(
+      AccountInfo user, Instant date, GroupInfo member) {
+    return new GroupMemberAuditEventInfo(Type.ADD_GROUP, user, date, member);
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public static GroupMemberAuditEventInfo createRemoveGroupEvent(
+      AccountInfo user, Optional<Timestamp> date, GroupInfo member) {
+    return new GroupMemberAuditEventInfo(
+        Type.REMOVE_GROUP, user, date.map(Timestamp::toInstant).orElse(null), member);
   }
 
   public static GroupMemberAuditEventInfo createRemoveGroupEvent(
-      AccountInfo user, Optional<Timestamp> date, GroupInfo member) {
+      AccountInfo user, @Nullable Instant date, GroupInfo member) {
     return new GroupMemberAuditEventInfo(Type.REMOVE_GROUP, user, date, member);
   }
 
@@ -55,11 +94,20 @@ public abstract class GroupAuditEventInfo {
     this.date = date.orElse(null);
   }
 
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  protected GroupAuditEventInfo(Type type, AccountInfo user, @Nullable Instant date) {
+    this.type = type;
+    this.user = user;
+    this.date = date != null ? Timestamp.from(date) : null;
+  }
+
   public static class UserMemberAuditEventInfo extends GroupAuditEventInfo {
     public AccountInfo member;
 
     private UserMemberAuditEventInfo(
-        Type type, AccountInfo user, Optional<Timestamp> date, AccountInfo member) {
+        Type type, AccountInfo user, @Nullable Instant date, AccountInfo member) {
       super(type, user, date);
       this.member = member;
     }
@@ -69,7 +117,7 @@ public abstract class GroupAuditEventInfo {
     public GroupInfo member;
 
     private GroupMemberAuditEventInfo(
-        Type type, AccountInfo user, Optional<Timestamp> date, GroupInfo member) {
+        Type type, AccountInfo user, @Nullable Instant date, GroupInfo member) {
       super(type, user, date);
       this.member = member;
     }

--- a/src/main/java/com/google/gerrit/extensions/common/GroupInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/GroupInfo.java
@@ -15,6 +15,7 @@
 package com.google.gerrit.extensions.common;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.List;
 
 public class GroupInfo extends GroupBaseInfo {
@@ -26,10 +27,28 @@ public class GroupInfo extends GroupBaseInfo {
   public Integer groupId;
   public String owner;
   public String ownerId;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp createdOn;
+
   public Boolean _moreGroups;
 
   // These fields are only supplied for internal groups, and only if requested.
   public List<AccountInfo> members;
   public List<GroupInfo> includes;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public Instant getCreatedOn() {
+    return createdOn.toInstant();
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public void setCreatedOn(Instant when) {
+    createdOn = Timestamp.from(when);
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/GroupsInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/GroupsInfo.java
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+/**
+ * Representation of group-related server configuration in the REST API.
+ *
+ * <p>This class determines the JSON format of group-related server configuration in the REST API.
+ */
+public class GroupsInfo {
+  /** The value of the {@code groups.enableDeleteGroup} parameter in {@code gerrit.config}. */
+  public Boolean enableDeleteGroup;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/HttpPasswordInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/HttpPasswordInput.java
@@ -14,6 +14,7 @@
 
 package com.google.gerrit.extensions.common;
 
+@Deprecated
 public class HttpPasswordInput {
   public String httpPassword;
   public boolean generate;

--- a/src/main/java/com/google/gerrit/extensions/common/InstallPluginInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/InstallPluginInput.java
@@ -17,7 +17,9 @@ package com.google.gerrit.extensions.common;
 import com.google.gerrit.extensions.restapi.DefaultInput;
 import com.google.gerrit.extensions.restapi.RawInput;
 
-/** @deprecated use {@link com.google.gerrit.extensions.api.plugins.InstallPluginInput}. */
+/**
+ * @deprecated use {@link com.google.gerrit.extensions.api.plugins.InstallPluginInput}.
+ */
 @Deprecated
 public class InstallPluginInput {
   public @DefaultInput String url;

--- a/src/main/java/com/google/gerrit/extensions/common/IsFlowsEnabledInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/IsFlowsEnabledInfo.java
@@ -1,0 +1,28 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+/**
+ * Representation of a boolean flag in the REST API.
+ *
+ * <p>This class determines the JSON format of boolean flags in the REST API.
+ */
+public class IsFlowsEnabledInfo {
+  public boolean enabled;
+
+  public IsFlowsEnabledInfo(boolean enabled) {
+    this.enabled = enabled;
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/LabelDefinitionInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/LabelDefinitionInfo.java
@@ -19,20 +19,43 @@ import java.util.Map;
 
 public class LabelDefinitionInfo {
   public String name;
+  public String description;
   public String projectName;
   public String function;
   public Map<String, String> values;
   public short defaultValue;
   public List<String> branches;
   public Boolean canOverride;
-  public Boolean copyAnyScore;
-  public Boolean copyMinScore;
-  public Boolean copyMaxScore;
-  public Boolean copyAllScoresIfNoChange;
-  public Boolean copyAllScoresIfNoCodeChange;
-  public Boolean copyAllScoresOnTrivialRebase;
-  public Boolean copyAllScoresOnMergeFirstParentUpdate;
-  public List<Short> copyValues;
+
+  // The individual copy-rule flags below were replaced upstream by the single copyCondition
+  // expression further down. They are kept here, deprecated, for source/binary compatibility with
+  // existing callers.
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyAnyScore;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyMinScore;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyMaxScore;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyAllScoresIfNoChange;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyAllScoresIfNoCodeChange;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyAllScoresOnTrivialRebase;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyAllScoresOnMergeFirstParentUpdate;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public List<Short> copyValues;
+
+  public String copyCondition;
   public Boolean allowPostSubmit;
   public Boolean ignoreSelfApproval;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/LabelDefinitionInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/LabelDefinitionInput.java
@@ -19,19 +19,43 @@ import java.util.Map;
 
 public class LabelDefinitionInput extends InputWithCommitMessage {
   public String name;
+  public String description;
   public String function;
   public Map<String, String> values;
   public Short defaultValue;
   public List<String> branches;
   public Boolean canOverride;
-  public Boolean copyAnyScore;
-  public Boolean copyMinScore;
-  public Boolean copyMaxScore;
-  public Boolean copyAllScoresIfNoChange;
-  public Boolean copyAllScoresIfNoCodeChange;
-  public Boolean copyAllScoresOnTrivialRebase;
-  public Boolean copyAllScoresOnMergeFirstParentUpdate;
-  public List<Short> copyValues;
+
+  // The individual copy-rule flags below were replaced upstream by the single copyCondition
+  // expression further down. They are kept here, deprecated, for source/binary compatibility with
+  // existing callers.
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyAnyScore;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyMinScore;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyMaxScore;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyAllScoresIfNoChange;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyAllScoresIfNoCodeChange;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyAllScoresOnTrivialRebase;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public Boolean copyAllScoresOnMergeFirstParentUpdate;
+
+  /** @deprecated removed upstream in favor of {@link #copyCondition}. */
+  @Deprecated public List<Short> copyValues;
+
+  public String copyCondition;
+  public Boolean unsetCopyCondition;
   public Boolean allowPostSubmit;
   public Boolean ignoreSelfApproval;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/LabelInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/LabelInfo.java
@@ -16,6 +16,7 @@ package com.google.gerrit.extensions.common;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class LabelInfo {
   public AccountInfo approved;
@@ -26,8 +27,42 @@ public class LabelInfo {
 
   public Map<String, String> values;
 
+  public String description;
   public Short value;
   public Short defaultValue;
   public Boolean optional;
   public Boolean blocking;
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof LabelInfo) {
+      LabelInfo labelInfo = (LabelInfo) o;
+      return Objects.equals(approved, labelInfo.approved)
+          && Objects.equals(rejected, labelInfo.rejected)
+          && Objects.equals(recommended, labelInfo.recommended)
+          && Objects.equals(disliked, labelInfo.disliked)
+          && Objects.equals(all, labelInfo.all)
+          && Objects.equals(values, labelInfo.values)
+          && Objects.equals(value, labelInfo.value)
+          && Objects.equals(defaultValue, labelInfo.defaultValue)
+          && Objects.equals(optional, labelInfo.optional)
+          && Objects.equals(blocking, labelInfo.blocking);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        approved,
+        rejected,
+        recommended,
+        disliked,
+        all,
+        values,
+        value,
+        defaultValue,
+        optional,
+        blocking);
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/LabelInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/LabelInfo.java
@@ -43,6 +43,7 @@ public class LabelInfo {
           && Objects.equals(disliked, labelInfo.disliked)
           && Objects.equals(all, labelInfo.all)
           && Objects.equals(values, labelInfo.values)
+          && Objects.equals(description, labelInfo.description)
           && Objects.equals(value, labelInfo.value)
           && Objects.equals(defaultValue, labelInfo.defaultValue)
           && Objects.equals(optional, labelInfo.optional)
@@ -60,6 +61,7 @@ public class LabelInfo {
         disliked,
         all,
         values,
+        description,
         value,
         defaultValue,
         optional,

--- a/src/main/java/com/google/gerrit/extensions/common/LegacySubmitRequirementInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/LegacySubmitRequirementInfo.java
@@ -1,0 +1,60 @@
+// Copyright (C) 2018 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+
+public class LegacySubmitRequirementInfo {
+  public String status;
+  public String fallbackText;
+  public String type;
+
+  public LegacySubmitRequirementInfo(String status, String fallbackText, String type) {
+    this.status = status;
+    this.fallbackText = fallbackText;
+    this.type = type;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LegacySubmitRequirementInfo)) {
+      return false;
+    }
+    LegacySubmitRequirementInfo that = (LegacySubmitRequirementInfo) o;
+    return Objects.equals(status, that.status)
+        && Objects.equals(fallbackText, that.fallbackText)
+        && Objects.equals(type, that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(status, fallbackText, type);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("status", status)
+        .add("fallbackText", fallbackText)
+        .add("type", type)
+        .toString();
+  }
+
+  protected LegacySubmitRequirementInfo() {}
+}

--- a/src/main/java/com/google/gerrit/extensions/common/ListTagSortOption.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ListTagSortOption.java
@@ -1,0 +1,20 @@
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+public enum ListTagSortOption {
+  REF,
+  CREATION_TIME,
+}

--- a/src/main/java/com/google/gerrit/extensions/common/MergePatchSetInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/MergePatchSetInput.java
@@ -14,9 +14,14 @@
 
 package com.google.gerrit.extensions.common;
 
+import com.google.gerrit.extensions.api.accounts.AccountInput;
+import java.util.Map;
+
 public class MergePatchSetInput {
   public String subject;
   public boolean inheritParent;
   public String baseChange;
   public MergeInput merge;
+  public AccountInput author;
+  public Map<String, String> validationOptions;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/MetadataInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/MetadataInfo.java
@@ -1,0 +1,70 @@
+// Copyright (C) 2024 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import com.google.common.base.MoreObjects;
+import com.google.gerrit.common.Nullable;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Metadata populated by plugins, see {code com.google.gerrit.server.account.AccountStateProvider}
+ * and {code com.google.gerrit.server.ServerStateProvider}.
+ */
+public class MetadataInfo {
+  /**
+   * The metadata name.
+   *
+   * <p>Not guaranteed to be unique, e.g. multiple metadata entries with the same name may be
+   * returned.
+   */
+  public String name;
+
+  /** The metadata value. May be unset. */
+  @Nullable public String value;
+
+  /** A description of the metadata. May be unset. */
+  @Nullable public String description;
+
+  /** Web links. May be unset. */
+  @Nullable public List<WebLinkInfo> webLinks;
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("value", value)
+        .add("description", description)
+        .add("webLinks", webLinks)
+        .toString();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value, description, webLinks);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof MetadataInfo) {
+      MetadataInfo metadata = (MetadataInfo) o;
+      return Objects.equals(name, metadata.name)
+          && Objects.equals(value, metadata.value)
+          && Objects.equals(description, metadata.description)
+          && Objects.equals(webLinks, metadata.webLinks);
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/NoMergeBaseReason.java
+++ b/src/main/java/com/google/gerrit/extensions/common/NoMergeBaseReason.java
@@ -1,0 +1,58 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import com.google.common.base.CaseFormat;
+
+/** Reasons why a merge base is not available. */
+public enum NoMergeBaseReason {
+  /**
+   * The revision has been created before Gerrit started to compute and store the base for
+   * conflicts.
+   */
+  HISTORIC_DATA_WITHOUT_BASE(0),
+
+  /** The merged commits do not have a common ancestor. */
+  NO_COMMON_ANCESTOR(1),
+
+  /**
+   * The merged commits have multiple merge bases (happens for criss-cross-merges) and the base was
+   * computed.
+   */
+  COMPUTED_BASE(2),
+
+  /**
+   * A one sided merge strategy (e.g. {@code ours} or {@code theirs}) has been used and computing a
+   * base was not required for the merge.
+   */
+  ONE_SIDED_MERGE_STRATEGY(3),
+
+  /** The revision was not created by performing a Git merge operation. */
+  NO_MERGE_PERFORMED(4);
+
+  private final int value;
+
+  NoMergeBaseReason(int v) {
+    this.value = v;
+  }
+
+  public int getValue() {
+    return value;
+  }
+
+  public String getDescription() {
+    return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.LOWER_HYPHEN, name()).replace('-', ' ');
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/PluginConfigInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/PluginConfigInfo.java
@@ -19,5 +19,7 @@ import java.util.List;
 public class PluginConfigInfo {
   public Boolean hasAvatars;
   public List<String> jsResourcePaths;
-  public List<String> htmlResourcePaths;
+
+  /** @deprecated removed upstream. */
+  @Deprecated public List<String> htmlResourcePaths;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/PluginDefinedInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/PluginDefinedInfo.java
@@ -14,6 +14,24 @@
 
 package com.google.gerrit.extensions.common;
 
+import java.util.Objects;
+
 public class PluginDefinedInfo {
   public String name;
+  public String message;
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof PluginDefinedInfo) {
+      PluginDefinedInfo pluginDefinedInfo = (PluginDefinedInfo) o;
+      return Objects.equals(name, pluginDefinedInfo.name)
+          && Objects.equals(message, pluginDefinedInfo.message);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, message);
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/ProjectInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ProjectInfo.java
@@ -27,4 +27,10 @@ public class ProjectInfo {
   public Map<String, String> branches;
   public List<WebLinkInfo> webLinks;
   public Map<String, LabelTypeInfo> labels;
+
+  /**
+   * Whether the query would deliver more results if not limited. Only set on the last project that
+   * is returned as a query result.
+   */
+  public Boolean _moreProjects;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/PushCertificateInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/PushCertificateInfo.java
@@ -14,7 +14,24 @@
 
 package com.google.gerrit.extensions.common;
 
+import java.util.Objects;
+
 public class PushCertificateInfo {
   public String certificate;
   public GpgKeyInfo key;
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof PushCertificateInfo) {
+      PushCertificateInfo pushCertificateInfo = (PushCertificateInfo) o;
+      return Objects.equals(certificate, pushCertificateInfo.certificate)
+          && Objects.equals(key, pushCertificateInfo.key);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(certificate, key);
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/RebaseChainInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/RebaseChainInfo.java
@@ -1,0 +1,28 @@
+// Copyright (C) 2022 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.List;
+
+public class RebaseChainInfo {
+  public List<ChangeInfo> rebasedChanges;
+
+  /**
+   * Whether any of the changes contain conflicts.
+   *
+   * <p>If {@code true}, some of the rebased changes are marked with conflicts.
+   */
+  public Boolean containsGitConflicts;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/ReviewerUpdateInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ReviewerUpdateInfo.java
@@ -16,10 +16,52 @@ package com.google.gerrit.extensions.common;
 
 import com.google.gerrit.extensions.client.ReviewerState;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Objects;
 
 public class ReviewerUpdateInfo {
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp updated;
+
   public AccountInfo updatedBy;
+  public AccountInfo realUpdatedBy;
   public AccountInfo reviewer;
   public ReviewerState state;
+
+  public ReviewerUpdateInfo() {}
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public ReviewerUpdateInfo(
+      Instant updated,
+      AccountInfo updatedBy,
+      AccountInfo realUpdatedBy,
+      AccountInfo reviewer,
+      ReviewerState state) {
+    this.updated = Timestamp.from(updated);
+    this.updatedBy = updatedBy;
+    this.realUpdatedBy = realUpdatedBy;
+    this.reviewer = reviewer;
+    this.state = state;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof ReviewerUpdateInfo) {
+      ReviewerUpdateInfo reviewerUpdateInfo = (ReviewerUpdateInfo) o;
+      return Objects.equals(updated, reviewerUpdateInfo.updated)
+          && Objects.equals(updatedBy, reviewerUpdateInfo.updatedBy)
+          && Objects.equals(realUpdatedBy, reviewerUpdateInfo.realUpdatedBy)
+          && Objects.equals(reviewer, reviewerUpdateInfo.reviewer)
+          && Objects.equals(state, reviewerUpdateInfo.state);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(updated, updatedBy, realUpdatedBy, reviewer, state);
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/RevisionInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/RevisionInfo.java
@@ -95,7 +95,8 @@ public class RevisionInfo {
           && Objects.equals(actions, revisionInfo.actions)
           && Objects.equals(commitWithFooters, revisionInfo.commitWithFooters)
           && Objects.equals(pushCertificate, revisionInfo.pushCertificate)
-          && Objects.equals(description, revisionInfo.description);
+          && Objects.equals(description, revisionInfo.description)
+          && Objects.equals(conflicts, revisionInfo.conflicts);
     }
     return false;
   }
@@ -118,7 +119,8 @@ public class RevisionInfo {
         actions,
         commitWithFooters,
         pushCertificate,
-        description);
+        description,
+        conflicts);
   }
 
   public static class ParentInfo {

--- a/src/main/java/com/google/gerrit/extensions/common/RevisionInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/RevisionInfo.java
@@ -16,7 +16,10 @@ package com.google.gerrit.extensions.common;
 
 import com.google.gerrit.extensions.client.ChangeKind;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class RevisionInfo {
   // ActionJson#copy(List, RevisionInfo) must be adapted if new fields are added that are not
@@ -24,14 +27,159 @@ public class RevisionInfo {
   public transient boolean isCurrent;
   public ChangeKind kind;
   public int _number;
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
   public Timestamp created;
+
   public AccountInfo uploader;
+  public AccountInfo realUploader;
   public String ref;
   public Map<String, FetchInfo> fetch;
   public CommitInfo commit;
+  public List<ParentInfo> parentsData;
+  public String branch;
   public Map<String, FileInfo> files;
   public Map<String, ActionInfo> actions;
   public String commitWithFooters;
   public PushCertificateInfo pushCertificate;
   public String description;
+
+  /**
+   * Information about conflicts in this revision.
+   *
+   * <p>Only set for revisions that were created by Gerrit as a result of performing a Git merge.
+   *
+   * <p>If this field is not set it's unknown whether the revision contains any file with conflicts.
+   */
+  public ConflictsInfo conflicts;
+
+  public RevisionInfo() {}
+
+  public RevisionInfo(String ref) {
+    this.ref = ref;
+  }
+
+  public RevisionInfo(String ref, int number) {
+    this.ref = ref;
+    _number = number;
+  }
+
+  public RevisionInfo(AccountInfo uploader) {
+    this.uploader = uploader;
+  }
+
+  // TODO(issue-40014498): Migrate timestamp fields in *Info/*Input classes from type Timestamp to
+  // Instant
+  @SuppressWarnings("JdkObsolete")
+  public void setCreated(Instant date) {
+    this.created = Timestamp.from(date);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof RevisionInfo) {
+      RevisionInfo revisionInfo = (RevisionInfo) o;
+      return isCurrent == revisionInfo.isCurrent
+          && Objects.equals(kind, revisionInfo.kind)
+          && _number == revisionInfo._number
+          && Objects.equals(created, revisionInfo.created)
+          && Objects.equals(uploader, revisionInfo.uploader)
+          && Objects.equals(realUploader, revisionInfo.realUploader)
+          && Objects.equals(ref, revisionInfo.ref)
+          && Objects.equals(fetch, revisionInfo.fetch)
+          && Objects.equals(commit, revisionInfo.commit)
+          && Objects.equals(parentsData, revisionInfo.parentsData)
+          && Objects.equals(branch, revisionInfo.branch)
+          && Objects.equals(files, revisionInfo.files)
+          && Objects.equals(actions, revisionInfo.actions)
+          && Objects.equals(commitWithFooters, revisionInfo.commitWithFooters)
+          && Objects.equals(pushCertificate, revisionInfo.pushCertificate)
+          && Objects.equals(description, revisionInfo.description);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        isCurrent,
+        kind,
+        _number,
+        created,
+        uploader,
+        realUploader,
+        ref,
+        fetch,
+        commit,
+        parentsData,
+        branch,
+        files,
+        actions,
+        commitWithFooters,
+        pushCertificate,
+        description);
+  }
+
+  public static class ParentInfo {
+    /** The name of the target branch where the patch-set commit is set to be merged into. */
+    public String branchName;
+
+    /** The commit SHA-1 of the parent commit. */
+    public String commitId;
+
+    /** Whether the parent commit is merged in the target branch. */
+    public Boolean isMergedInTargetBranch;
+
+    /**
+     * If the parent commit is a patch-set of another gerrit change, this field will hold the change
+     * ID of the parent change. Otherwise, will be null.
+     */
+    public String changeId;
+
+    /**
+     * If the parent commit is a patch-set of another gerrit change, this field will hold the change
+     * number of the parent change. Otherwise, will be null.
+     */
+    public Integer changeNumber;
+
+    /**
+     * If the parent commit is a patch-set of another gerrit change, this field will hold the
+     * patch-set number of the parent change. Otherwise, will be null.
+     */
+    public Integer patchSetNumber;
+
+    /**
+     * If the parent commit is a patch-set of another gerrit change, this field will hold the change
+     * status of the parent change. Otherwise, will be null.
+     */
+    public String changeStatus;
+
+    @Override
+    public boolean equals(Object o) {
+      if (o instanceof ParentInfo) {
+        ParentInfo parentInfo = (ParentInfo) o;
+        return Objects.equals(branchName, parentInfo.branchName)
+            && Objects.equals(commitId, parentInfo.commitId)
+            && Objects.equals(isMergedInTargetBranch, parentInfo.isMergedInTargetBranch)
+            && Objects.equals(changeId, parentInfo.changeId)
+            && Objects.equals(changeNumber, parentInfo.changeNumber)
+            && Objects.equals(patchSetNumber, parentInfo.patchSetNumber)
+            && Objects.equals(changeStatus, parentInfo.changeStatus);
+      }
+      return false;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          branchName,
+          commitId,
+          isMergedInTargetBranch,
+          changeId,
+          changeNumber,
+          patchSetNumber,
+          changeStatus);
+    }
+  }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/RobotCommentInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/RobotCommentInfo.java
@@ -14,7 +14,6 @@
 
 package com.google.gerrit.extensions.common;
 
-import java.util.List;
 import java.util.Map;
 
 public class RobotCommentInfo extends CommentInfo {
@@ -22,5 +21,4 @@ public class RobotCommentInfo extends CommentInfo {
   public String robotRunId;
   public String url;
   public Map<String, String> properties;
-  public List<FixSuggestionInfo> fixSuggestions;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/ServerInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ServerInfo.java
@@ -14,6 +14,8 @@
 
 package com.google.gerrit.extensions.common;
 
+import java.util.List;
+
 /** API response containing values from {@code gerrit.config} as nested objects. */
 public class ServerInfo {
   public AccountsInfo accounts;
@@ -21,6 +23,7 @@ public class ServerInfo {
   public ChangeConfigInfo change;
   public DownloadInfo download;
   public GerritInfo gerrit;
+  public GroupsInfo groups;
   public Boolean noteDbEnabled;
   public PluginConfigInfo plugin;
   public SshdInfo sshd;
@@ -28,4 +31,9 @@ public class ServerInfo {
   public UserConfigInfo user;
   public ReceiveInfo receive;
   public String defaultTheme;
+  public List<String> submitRequirementDashboardColumns;
+  public Boolean dashboardShowAllLabels;
+
+  /** Server metadata populated by plugins. */
+  public List<MetadataInfo> metadata;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/SubmitRecordInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/SubmitRecordInfo.java
@@ -1,0 +1,89 @@
+// Copyright (C) 2021 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.List;
+import java.util.Objects;
+
+/** API response containing a {@link com.google.gerrit.entities.SubmitRecord} entity. */
+public class SubmitRecordInfo {
+  public enum Status {
+    OK,
+    NOT_READY,
+    CLOSED,
+    FORCED,
+    RULE_ERROR
+  }
+
+  public static class Label {
+    public enum Status {
+      OK,
+      REJECT,
+      NEED,
+      MAY,
+      IMPOSSIBLE
+    }
+
+    public String label;
+    public Label.Status status;
+    public AccountInfo appliedBy;
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Label)) {
+        return false;
+      }
+      Label that = (Label) o;
+      return Objects.equals(label, that.label)
+          && status == that.status
+          && Objects.equals(appliedBy, that.appliedBy);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(label, status, appliedBy);
+    }
+  }
+
+  public String ruleName;
+  public Status status;
+  public List<Label> labels;
+  public List<LegacySubmitRequirementInfo> requirements;
+  public String errorMessage;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SubmitRecordInfo)) {
+      return false;
+    }
+    SubmitRecordInfo that = (SubmitRecordInfo) o;
+    return Objects.equals(ruleName, that.ruleName)
+        && status == that.status
+        && Objects.equals(labels, that.labels)
+        && Objects.equals(requirements, that.requirements)
+        && Objects.equals(errorMessage, that.errorMessage);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(ruleName, status, labels, requirements, errorMessage);
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/SubmitRequirementExpressionInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/SubmitRequirementExpressionInfo.java
@@ -1,0 +1,107 @@
+// Copyright (C) 2021 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Result of evaluating a single submit requirement expression. This API entity is populated from
+ * {@link com.google.gerrit.entities.SubmitRequirementExpressionResult}.
+ */
+public class SubmitRequirementExpressionInfo {
+
+  /** Submit requirement expression as a String. */
+  public String expression;
+
+  /** A boolean indicating if the expression is fulfilled on a change. */
+  public boolean fulfilled;
+
+  /** A status indicating if the expression is fulfilled, non-fulfilled or not evaluated. */
+  public Status status;
+
+  /**
+   * A list of all atoms that are passing, for example query "branch:refs/heads/foo and project:bar"
+   * has two atoms: ["branch:refs/heads/foo", "project:bar"].
+   */
+  public List<String> passingAtoms;
+
+  /**
+   * A list of all atoms that are failing, for example query "branch:refs/heads/foo and project:bar"
+   * has two atoms: ["branch:refs/heads/foo", "project:bar"].
+   */
+  public List<String> failingAtoms;
+
+  /**
+   * Map of leaf predicates to their explanations.
+   *
+   * <p>This is used to provide more information about complex atoms, which may otherwise be opaque
+   * and hard to debug.
+   *
+   * <p>This will only be populated/implemented for some atoms.
+   */
+  public Map<String, String> atomExplanations;
+
+  /**
+   * Optional error message. Contains an explanation of why the submit requirement expression failed
+   * during its evaluation.
+   */
+  public String errorMessage;
+
+  /**
+   * Values in this enum should match with values in {@link
+   * com.google.gerrit.entities.SubmitRequirementExpressionResult.Status}.
+   */
+  public enum Status {
+    /** Expression was evaluated and the result was true. */
+    PASS,
+
+    /** Expression was evaluated and the result was false. */
+    FAIL,
+
+    /** An error occurred while evaluating the expression. */
+    ERROR,
+
+    /** Expression was not evaluated. */
+    NOT_EVALUATED,
+
+    /** Submit requirement expression was timeout as maintained in gerrit.config. */
+    TIMEOUT
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SubmitRequirementExpressionInfo)) {
+      return false;
+    }
+    SubmitRequirementExpressionInfo that = (SubmitRequirementExpressionInfo) o;
+    return fulfilled == that.fulfilled
+        && Objects.equals(expression, that.expression)
+        && Objects.equals(passingAtoms, that.passingAtoms)
+        && Objects.equals(failingAtoms, that.failingAtoms)
+        && Objects.equals(atomExplanations, that.atomExplanations)
+        && Objects.equals(errorMessage, that.errorMessage);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        expression, fulfilled, passingAtoms, failingAtoms, atomExplanations, errorMessage);
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/SubmitRequirementExpressionInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/SubmitRequirementExpressionInfo.java
@@ -93,6 +93,7 @@ public class SubmitRequirementExpressionInfo {
     SubmitRequirementExpressionInfo that = (SubmitRequirementExpressionInfo) o;
     return fulfilled == that.fulfilled
         && Objects.equals(expression, that.expression)
+        && status == that.status
         && Objects.equals(passingAtoms, that.passingAtoms)
         && Objects.equals(failingAtoms, that.failingAtoms)
         && Objects.equals(atomExplanations, that.atomExplanations)
@@ -102,6 +103,6 @@ public class SubmitRequirementExpressionInfo {
   @Override
   public int hashCode() {
     return Objects.hash(
-        expression, fulfilled, passingAtoms, failingAtoms, atomExplanations, errorMessage);
+        expression, fulfilled, status, passingAtoms, failingAtoms, atomExplanations, errorMessage);
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/SubmitRequirementInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/SubmitRequirementInfo.java
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 The Android Open Source Project
+// Copyright (C) 2022 The Android Open Source Project
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,45 +14,67 @@
 
 package com.google.gerrit.extensions.common;
 
-import com.google.common.base.MoreObjects;
-import java.util.Objects;
-
 public class SubmitRequirementInfo {
-  public final String status;
-  public final String fallbackText;
-  public final String type;
+  /**
+   * @deprecated removed upstream; this class was repurposed for submit requirement definitions (see
+   *     {@link #name}, {@link #description}, ...). Use {@link SubmitRequirementResultInfo} for the
+   *     result of evaluating a submit requirement on a change instead. Kept here for source/binary
+   *     compatibility with existing callers.
+   */
+  @Deprecated public final String status;
 
+  /** @deprecated see {@link #status}. */
+  @Deprecated public final String fallbackText;
+
+  /** @deprecated see {@link #status}. */
+  @Deprecated public final String type;
+
+  public SubmitRequirementInfo() {
+    status = null;
+    fallbackText = null;
+    type = null;
+  }
+
+  /** @deprecated see {@link #status}; kept for source/binary compatibility with existing callers. */
+  @Deprecated
   public SubmitRequirementInfo(String status, String fallbackText, String type) {
     this.status = status;
     this.fallbackText = fallbackText;
     this.type = type;
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (!(o instanceof SubmitRequirementInfo)) {
-      return false;
-    }
-    SubmitRequirementInfo that = (SubmitRequirementInfo) o;
-    return Objects.equals(status, that.status)
-        && Objects.equals(fallbackText, that.fallbackText)
-        && Objects.equals(type, that.type);
-  }
+  /** Name of the submit requirement. */
+  public String name;
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(status, fallbackText, type);
-  }
+  /** Description of the submit requirement. */
+  public String description;
 
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("status", status)
-        .add("fallbackText", fallbackText)
-        .add("type", type)
-        .toString();
-  }
+  /**
+   * The name of the project that defines this submit requirement.
+   *
+   * <p>{@code null} if the it's a global submit requirement.
+   */
+  public String projectName;
+
+  /**
+   * Expression string to be evaluated on a change. Decides if this submit requirement is applicable
+   * on the given change.
+   */
+  public String applicabilityExpression;
+
+  /**
+   * Expression string to be evaluated on a change. When evaluated to true, this submit requirement
+   * becomes fulfilled for this change.
+   */
+  public String submittabilityExpression;
+
+  /**
+   * Expression string to be evaluated on a change. When evaluated to true, this submit requirement
+   * becomes fulfilled for this change regardless of the evaluation of the {@link
+   * #submittabilityExpression}.
+   */
+  public String overrideExpression;
+
+  /** Boolean indicating if this submit requirement can be overridden in child projects. */
+  public boolean allowOverrideInChildProjects;
 }

--- a/src/main/java/com/google/gerrit/extensions/common/SubmitRequirementInput.java
+++ b/src/main/java/com/google/gerrit/extensions/common/SubmitRequirementInput.java
@@ -1,0 +1,45 @@
+// Copyright (C) 2021 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+/** API Input describing a submit requirement entity. */
+public class SubmitRequirementInput {
+  /** Submit requirement name. */
+  public String name;
+
+  /** Submit requirement description. */
+  public String description;
+
+  /**
+   * Query expression that can be evaluated on any change. If evaluated to true on a change, the
+   * submit requirement is then applicable on this change.
+   */
+  public String applicabilityExpression;
+
+  /**
+   * Query expression that can be evaluated on any change. If evaluated to true on a change, the
+   * submit requirement is fulfilled and not blocking change submission.
+   */
+  public String submittabilityExpression;
+
+  /**
+   * Query expression that can be evaluated on any change. If evaluated to true on a change, the
+   * submit requirement is overridden and not blocking change submission.
+   */
+  public String overrideExpression;
+
+  /** Whether this submit requirement can be overridden in child projects. */
+  public Boolean allowOverrideInChildProjects;
+}

--- a/src/main/java/com/google/gerrit/extensions/common/SubmitRequirementResultInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/SubmitRequirementResultInfo.java
@@ -1,0 +1,109 @@
+// Copyright (C) 2021 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import com.google.gerrit.common.Nullable;
+import java.util.Objects;
+
+/** Result of evaluating a submit requirement on a change. */
+public class SubmitRequirementResultInfo {
+  public enum Status {
+    /** Submit requirement is fulfilled. */
+    SATISFIED,
+
+    /**
+     * Submit requirement is not satisfied. Happens when {@code submittabilityExpressionResult} is
+     * not fulfilled.
+     */
+    UNSATISFIED,
+
+    /**
+     * Submit requirement is overridden. Happens when {@code overrideExpressionResult} is fulfilled.
+     */
+    OVERRIDDEN,
+
+    /**
+     * Submit requirement is not applicable for the change. Happens when {@code
+     * applicabilityExpressionResult} is not fulfilled.
+     */
+    NOT_APPLICABLE,
+
+    /**
+     * Any of the applicability, submittability or override expressions contain invalid syntax and
+     * are not parsable.
+     */
+    ERROR,
+
+    /**
+     * The "submit requirement" was bypassed during submission, e.g. by pushing for review with the
+     * %submit option.
+     */
+    FORCED,
+
+    /** The submit requirement is TIMEOUT during evaluation. */
+    TIMEOUT
+  }
+
+  /** Submit requirement name. */
+  public String name;
+
+  /** Submit requirement description. */
+  public String description;
+
+  /** Overall result (status) of evaluating this submit requirement. */
+  public Status status;
+
+  /** Whether this result was created from a legacy submit record. */
+  public boolean isLegacy;
+
+  /** Result of evaluating the applicability expression. */
+  @Nullable public SubmitRequirementExpressionInfo applicabilityExpressionResult;
+
+  /** Result of evaluating the submittability expression. */
+  @Nullable public SubmitRequirementExpressionInfo submittabilityExpressionResult;
+
+  /** Result of evaluating the override expression. */
+  @Nullable public SubmitRequirementExpressionInfo overrideExpressionResult;
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof SubmitRequirementResultInfo)) {
+      return false;
+    }
+    SubmitRequirementResultInfo that = (SubmitRequirementResultInfo) o;
+    return isLegacy == that.isLegacy
+        && Objects.equals(name, that.name)
+        && Objects.equals(description, that.description)
+        && status == that.status
+        && Objects.equals(applicabilityExpressionResult, that.applicabilityExpressionResult)
+        && Objects.equals(submittabilityExpressionResult, that.submittabilityExpressionResult)
+        && Objects.equals(overrideExpressionResult, that.overrideExpressionResult);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        name,
+        description,
+        status,
+        isLegacy,
+        applicabilityExpressionResult,
+        submittabilityExpressionResult,
+        overrideExpressionResult);
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/TestSubmitRuleInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/TestSubmitRuleInfo.java
@@ -19,7 +19,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public class TestSubmitRuleInfo {
-  /** @see com.google.gerrit.entities.SubmitRecord.Status */
+  /** See {@link com.google.gerrit.entities.SubmitRecord.Status} */
   public String status;
 
   public String errorMessage;

--- a/src/main/java/com/google/gerrit/extensions/common/TrackingIdInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/TrackingIdInfo.java
@@ -14,6 +14,8 @@
 
 package com.google.gerrit.extensions.common;
 
+import java.util.Objects;
+
 public class TrackingIdInfo {
   public String system;
   public String id;
@@ -22,4 +24,20 @@ public class TrackingIdInfo {
     this.system = system;
     this.id = id;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof TrackingIdInfo) {
+      TrackingIdInfo trackingIdInfo = (TrackingIdInfo) o;
+      return Objects.equals(system, trackingIdInfo.system) && Objects.equals(id, trackingIdInfo.id);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(system, id);
+  }
+
+  protected TrackingIdInfo() {}
 }

--- a/src/main/java/com/google/gerrit/extensions/common/ValidationOptionInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ValidationOptionInfo.java
@@ -1,0 +1,43 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import java.util.Objects;
+
+/** Representation of a validation option that the user can specify upon upload. */
+public class ValidationOptionInfo {
+  public final String name;
+  public final String description;
+
+  public ValidationOptionInfo(String name, String description) {
+    this.name = name;
+    this.description = description;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof ValidationOptionInfo) {
+      ValidationOptionInfo validationInfo = (ValidationOptionInfo) o;
+      return Objects.equals(name, validationInfo.name)
+          && Objects.equals(description, validationInfo.description);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, description);
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/ValidationOptionInfos.java
+++ b/src/main/java/com/google/gerrit/extensions/common/ValidationOptionInfos.java
@@ -1,0 +1,25 @@
+// Copyright (C) 2025 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.common;
+
+import com.google.common.collect.ImmutableList;
+
+public class ValidationOptionInfos {
+  public final ImmutableList<ValidationOptionInfo> validationOptions;
+
+  public ValidationOptionInfos(ImmutableList<ValidationOptionInfo> validationOptions) {
+    this.validationOptions = validationOptions;
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/common/VotingRangeInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/VotingRangeInfo.java
@@ -14,6 +14,8 @@
 
 package com.google.gerrit.extensions.common;
 
+import java.util.Objects;
+
 public class VotingRangeInfo {
   public int min;
   public int max;
@@ -21,5 +23,19 @@ public class VotingRangeInfo {
   public VotingRangeInfo(int min, int max) {
     this.min = min;
     this.max = max;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof VotingRangeInfo) {
+      VotingRangeInfo votingRangeInfo = (VotingRangeInfo) o;
+      return min == votingRangeInfo.min && max == votingRangeInfo.max;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(min, max);
   }
 }

--- a/src/main/java/com/google/gerrit/extensions/common/WebLinkInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/WebLinkInfo.java
@@ -14,25 +14,29 @@
 
 package com.google.gerrit.extensions.common;
 
-//import com.google.gerrit.extensions.webui.WebLink.Target;
 import java.util.Objects;
 
 public class WebLinkInfo {
   public String name;
+  public String tooltip;
   public String imageUrl;
   public String url;
-  public String target;
 
-  public WebLinkInfo(String name, String imageUrl, String url, String target) {
+  /** @deprecated removed upstream; the underlying REST resource may still exist. */
+  @Deprecated public String target;
+
+  public WebLinkInfo(String name, String imageUrl, String url) {
     this.name = name;
     this.imageUrl = imageUrl;
     this.url = url;
-    this.target = target;
   }
 
-//  public WebLinkInfo(String name, String imageUrl, String url) {
-//    this(name, imageUrl, url, Target.SELF);
-//  }
+  /** @deprecated removed upstream; kept for source/binary compatibility with existing callers. */
+  @Deprecated
+  public WebLinkInfo(String name, String imageUrl, String url, String target) {
+    this(name, imageUrl, url);
+    this.target = target;
+  }
 
   @Override
   public boolean equals(Object o) {
@@ -41,14 +45,14 @@ public class WebLinkInfo {
     }
     WebLinkInfo i = (WebLinkInfo) o;
     return Objects.equals(name, i.name)
+        && Objects.equals(tooltip, i.tooltip)
         && Objects.equals(imageUrl, i.imageUrl)
-        && Objects.equals(url, i.url)
-        && Objects.equals(target, i.target);
+        && Objects.equals(url, i.url);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, imageUrl, url, target);
+    return Objects.hash(name, tooltip, imageUrl, url);
   }
 
   @Override
@@ -56,12 +60,14 @@ public class WebLinkInfo {
     return getClass().getSimpleName()
         + "{name="
         + name
+        + ", tooltip="
+        + tooltip
         + ", imageUrl="
         + imageUrl
         + ", url="
         + url
-        + ", target"
-        + target
         + "}";
   }
+
+  protected WebLinkInfo() {}
 }

--- a/src/main/java/com/google/gerrit/extensions/common/WebLinkInfo.java
+++ b/src/main/java/com/google/gerrit/extensions/common/WebLinkInfo.java
@@ -47,12 +47,13 @@ public class WebLinkInfo {
     return Objects.equals(name, i.name)
         && Objects.equals(tooltip, i.tooltip)
         && Objects.equals(imageUrl, i.imageUrl)
-        && Objects.equals(url, i.url);
+        && Objects.equals(url, i.url)
+        && Objects.equals(target, i.target);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, tooltip, imageUrl, url);
+    return Objects.hash(name, tooltip, imageUrl, url, target);
   }
 
   @Override

--- a/src/main/java/com/google/gerrit/extensions/restapi/BadRequestException.java
+++ b/src/main/java/com/google/gerrit/extensions/restapi/BadRequestException.java
@@ -1,0 +1,35 @@
+// Copyright (C) 2012 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.restapi;
+
+/** Request could not be parsed as sent (HTTP 400 Bad Request). */
+public class BadRequestException extends RestApiException {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * @param msg error text for client describing how request is bad.
+   */
+  public BadRequestException(String msg) {
+    super(msg);
+  }
+
+  /**
+   * @param msg error text for client describing how request is bad.
+   * @param cause cause of this exception.
+   */
+  public BadRequestException(String msg, Throwable cause) {
+    super(msg, cause);
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/restapi/BinaryResult.java
+++ b/src/main/java/com/google/gerrit/extensions/restapi/BinaryResult.java
@@ -16,6 +16,7 @@ package com.google.gerrit.extensions.restapi;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
@@ -63,7 +64,7 @@ public abstract class BinaryResult implements Closeable {
   private boolean base64;
   private String attachmentName;
 
-  /** @return the MIME type of the result, for HTTP clients. */
+  /** Returns the MIME type of the result, for HTTP clients. */
   public String getContentType() {
     Charset enc = getCharacterEncoding();
     if (enc != null) {
@@ -73,6 +74,7 @@ public abstract class BinaryResult implements Closeable {
   }
 
   /** Set the MIME type of the result, and return {@code this}. */
+  @CanIgnoreReturnValue
   public BinaryResult setContentType(String contentType) {
     this.contentType = contentType != null ? contentType : OCTET_STREAM;
     return this;
@@ -84,6 +86,7 @@ public abstract class BinaryResult implements Closeable {
   }
 
   /** Set the character set used to encode text data and return {@code this}. */
+  @CanIgnoreReturnValue
   public BinaryResult setCharacterEncoding(Charset encoding) {
     characterEncoding = encoding;
     return this;
@@ -95,39 +98,43 @@ public abstract class BinaryResult implements Closeable {
   }
 
   /** Set the attachment file name and return {@code this}. */
+  @CanIgnoreReturnValue
   public BinaryResult setAttachmentName(String attachmentName) {
     this.attachmentName = attachmentName;
     return this;
   }
 
-  /** @return length in bytes of the result; -1 if not known. */
+  /** Returns length in bytes of the result; -1 if not known. */
   public long getContentLength() {
     return contentLength;
   }
 
   /** Set the content length of the result; -1 if not known. */
+  @CanIgnoreReturnValue
   public BinaryResult setContentLength(long len) {
     this.contentLength = len;
     return this;
   }
 
-  /** @return true if this result can be gzip compressed to clients. */
+  /** Returns true if this result can be gzip compressed to clients. */
   public boolean canGzip() {
     return gzip;
   }
 
   /** Disable gzip compression for already compressed responses. */
+  @CanIgnoreReturnValue
   public BinaryResult disableGzip() {
     this.gzip = false;
     return this;
   }
 
-  /** @return true if the result must be base64 encoded. */
+  /** Returns true if the result must be base64 encoded. */
   public boolean isBase64() {
     return base64;
   }
 
   /** Wrap the binary data in base64 encoding. */
+  @CanIgnoreReturnValue
   public BinaryResult base64() {
     base64 = true;
     return this;

--- a/src/main/java/com/google/gerrit/extensions/restapi/IdString.java
+++ b/src/main/java/com/google/gerrit/extensions/restapi/IdString.java
@@ -36,17 +36,26 @@ public class IdString {
     urlEncoded = s;
   }
 
-  /** @return the decoded value of the string. */
+  /** Returns the decoded value of the string. */
   public String get() {
-    return Url.decode(urlEncoded);
+    String data = urlEncoded;
+
+    // URLs use percentage encoding which replaces unsafe ASCII characters with a '%' followed by
+    // two hexadecimal digits. If there is '%' that is not followed by two hexadecimal digits
+    // Url.decode(String) fails with an IllegalArgumentException. To prevent this replace any '%'
+    // that is not followed by two hexadecimal digits by "%25", which is the URL encoding for '%',
+    // before calling Url.decode(String).
+    data = data.replaceAll("%(?![0-9a-fA-F]{2})", "%25");
+
+    return Url.decode(data);
   }
 
-  /** @return true if the string is the empty string. */
+  /** Returns true if the string is the empty string. */
   public boolean isEmpty() {
     return urlEncoded.isEmpty();
   }
 
-  /** @return the original URL encoding supplied by the client. */
+  /** Returns the original URL encoding supplied by the client. */
   public String encoded() {
     return urlEncoded;
   }

--- a/src/main/java/com/google/gerrit/extensions/restapi/Response.java
+++ b/src/main/java/com/google/gerrit/extensions/restapi/Response.java
@@ -1,0 +1,317 @@
+// Copyright (C) 2012 The Android Open Source Project
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.gerrit.extensions.restapi;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import java.util.concurrent.TimeUnit;
+
+/** Special return value to mean specific HTTP status codes in a REST API. */
+public abstract class Response<T> {
+  // Intentionally keep this constant local to avoid introducing an HTTP library
+  // dependency into the public gerrit-extension-api.
+  private static final int HTTP_INTERNAL_SERVER_ERROR = 500;
+
+  @SuppressWarnings({"rawtypes"})
+  private static final Response NONE = new None();
+
+  /** HTTP 200 OK: pointless wrapper for type safety. */
+  public static <T> Response<T> ok(T value) {
+    return ok(value, ImmutableMultimap.of());
+  }
+
+  public static <T> Response<T> ok(T value, ImmutableMultimap<String, String> headers) {
+    return new Impl<>(200, value, headers);
+  }
+
+  /** HTTP 200 OK: with empty value. */
+  public static Response<String> ok() {
+    return ok("");
+  }
+
+  /** HTTP 200 OK: with forced revalidation of cache. */
+  public static <T> Response<T> withMustRevalidate(T value) {
+    return ok(value).caching(CacheControl.PRIVATE(0, TimeUnit.SECONDS).setMustRevalidate());
+  }
+
+  /** HTTP 201 Created: typically used when a new resource is made. */
+  public static <T> Response<T> created(T value) {
+    return new Impl<>(201, value);
+  }
+
+  /** HTTP 201 Created: with empty value. */
+  public static Response<String> created() {
+    return created("");
+  }
+
+  /** HTTP 202 Accepted: accepted as background task. */
+  public static Accepted accepted(String location) {
+    return new Accepted(location);
+  }
+
+  /** HTTP 204 No Content: typically used when the resource is deleted. */
+  @SuppressWarnings("unchecked")
+  public static <T> Response<T> none() {
+    return NONE;
+  }
+
+  /** HTTP 302 Found: temporary redirect to another URL. */
+  public static Redirect redirect(String location) {
+    return new Redirect(location);
+  }
+
+  /** Arbitrary status code with wrapped result. */
+  public static <T> Response<T> withStatusCode(int statusCode, T value) {
+    checkState(
+        statusCode < HTTP_INTERNAL_SERVER_ERROR,
+        "Status code must be < 500. To return an internal server error REST endpoint"
+            + " implementations should throw an exception");
+    return new Impl<>(statusCode, value);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public static <T> T unwrap(T obj) {
+    while (obj instanceof Response) {
+      obj = (T) ((Response) obj).value();
+    }
+    return obj;
+  }
+
+  public abstract boolean isNone();
+
+  public abstract int statusCode();
+
+  public abstract T value();
+
+  public abstract ImmutableMultimap<String, String> headers();
+
+  public abstract CacheControl caching();
+
+  @CanIgnoreReturnValue
+  public abstract Response<T> caching(CacheControl c);
+
+  @Override
+  public abstract String toString();
+
+  private static final class Impl<T> extends Response<T> {
+    private final int statusCode;
+    private final T value;
+    private final ImmutableMultimap<String, String> headers;
+    private CacheControl caching = CacheControl.NONE;
+
+    private Impl(int sc, T val) {
+      this(sc, val, ImmutableMultimap.of());
+    }
+
+    private Impl(int sc, T val, ImmutableMultimap<String, String> hs) {
+      statusCode = sc;
+      value = val;
+      headers = hs;
+    }
+
+    @Override
+    public boolean isNone() {
+      return false;
+    }
+
+    @Override
+    public int statusCode() {
+      return statusCode;
+    }
+
+    @Override
+    public T value() {
+      return value;
+    }
+
+    @Override
+    public ImmutableMultimap<String, String> headers() {
+      return headers;
+    }
+
+    @Override
+    public CacheControl caching() {
+      return caching;
+    }
+
+    @Override
+    public Response<T> caching(CacheControl c) {
+      caching = c;
+      return this;
+    }
+
+    @Override
+    public String toString() {
+      return "[" + statusCode() + "] " + value();
+    }
+  }
+
+  private static final class None extends Response<Object> {
+    private None() {}
+
+    @Override
+    public boolean isNone() {
+      return true;
+    }
+
+    @Override
+    public int statusCode() {
+      return 204;
+    }
+
+    @Override
+    public Object value() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ImmutableMultimap<String, String> headers() {
+      return ImmutableMultimap.of();
+    }
+
+    @Override
+    public CacheControl caching() {
+      return CacheControl.NONE;
+    }
+
+    @Override
+    public Response<Object> caching(CacheControl c) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String toString() {
+      return "[204 No Content] None";
+    }
+  }
+
+  /** An HTTP redirect to another location. */
+  public static final class Redirect extends Response<Object> {
+    private final String location;
+
+    private Redirect(String url) {
+      this.location = url;
+    }
+
+    @Override
+    public boolean isNone() {
+      return false;
+    }
+
+    @Override
+    public int statusCode() {
+      return 302;
+    }
+
+    @Override
+    public Object value() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ImmutableMultimap<String, String> headers() {
+      return ImmutableMultimap.of();
+    }
+
+    @Override
+    public CacheControl caching() {
+      return CacheControl.NONE;
+    }
+
+    @Override
+    public Response<Object> caching(CacheControl c) {
+      throw new UnsupportedOperationException();
+    }
+
+    public String location() {
+      return location;
+    }
+
+    @Override
+    public int hashCode() {
+      return location.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof Redirect && ((Redirect) o).location.equals(location);
+    }
+
+    @Override
+    public String toString() {
+      return String.format("[302 Redirect] %s", location);
+    }
+  }
+
+  /** Accepted as task for asynchronous execution. */
+  public static final class Accepted extends Response<Object> {
+    private final String location;
+
+    private Accepted(String url) {
+      this.location = url;
+    }
+
+    @Override
+    public boolean isNone() {
+      return false;
+    }
+
+    @Override
+    public int statusCode() {
+      return 202;
+    }
+
+    @Override
+    public Object value() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ImmutableMultimap<String, String> headers() {
+      return ImmutableMultimap.of();
+    }
+
+    @Override
+    public CacheControl caching() {
+      return CacheControl.NONE;
+    }
+
+    @Override
+    public Response<Object> caching(CacheControl c) {
+      throw new UnsupportedOperationException();
+    }
+
+    public String location() {
+      return location;
+    }
+
+    @Override
+    public int hashCode() {
+      return location.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return o instanceof Accepted && ((Accepted) o).location.equals(location);
+    }
+
+    @Override
+    public String toString() {
+      return String.format("[202 Accepted] %s", location);
+    }
+  }
+}

--- a/src/main/java/com/google/gerrit/extensions/restapi/Url.java
+++ b/src/main/java/com/google/gerrit/extensions/restapi/Url.java
@@ -16,6 +16,7 @@ package com.google.gerrit.extensions.restapi;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.google.gerrit.common.Nullable;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -40,6 +41,7 @@ public final class Url {
    * @param component a string containing text to encode.
    * @return a string with all invalid URL characters escaped.
    */
+  @Nullable
   public static String encode(String component) {
     if (component != null) {
       try {
@@ -52,6 +54,7 @@ public final class Url {
   }
 
   /** Decode a URL encoded string, e.g. from {@code "%2F"} to {@code "/"}. */
+  @Nullable
   public static String decode(String str) {
     if (str != null) {
       try {

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClient.java
@@ -236,10 +236,11 @@ public class ChangeApiRestClient extends ChangeApi.NotImplemented implements Cha
     }
 
     @Override
-    public AddReviewerResult addReviewer(String in) throws RestApiException {
-        AddReviewerInput input = new AddReviewerInput();
-        input.reviewer = in;
-        return addReviewer(input);
+    public ReviewerResult addReviewer(ReviewerInput in) throws RestApiException {
+        String request = getRequestPath() + "/reviewers";
+        String json = gerritRestClient.getGson().toJson(in);
+        JsonElement reviewerResult = gerritRestClient.postRequest(request, json);
+        return reviewerInfosParser.parseReviewerResult(reviewerResult);
     }
 
     @Override

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeEditApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeEditApiRestClient.java
@@ -119,7 +119,7 @@ public class ChangeEditApiRestClient extends ChangeEditApi.NotImplemented implem
         String encodedPath = Url.encode(filePath);
         String request = getRequestPath() + "/" + encodedPath;
         try {
-            gerritRestClient.request(request, input.binary_content, HttpVerb.PUT_TEXT_PLAIN);
+            gerritRestClient.request(request, input.binaryContent, HttpVerb.PUT_TEXT_PLAIN);
         } catch (IOException e) {
             throw RestApiException.wrap("Failed to modify file.", e);
         }

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClient.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClient.java
@@ -92,15 +92,16 @@ public class RevisionApiRestClient extends RevisionApi.NotImplemented implements
     }
 
     @Override
-    public void submit() throws RestApiException {
-        submit(new SubmitInput());
+    public ChangeInfo submit() throws RestApiException {
+        return submit(new SubmitInput());
     }
 
     @Override
-    public void submit(SubmitInput submitInput) throws RestApiException {
+    public ChangeInfo submit(SubmitInput submitInput) throws RestApiException {
         String request = changeApiRestClient.getRequestPath() + "/submit";
         String json = gerritRestClient.getGson().toJson(submitInput);
-        gerritRestClient.postRequest(request, json);
+        JsonElement result = gerritRestClient.postRequest(request, json);
+        return gerritRestClient.getGson().fromJson(result, ChangeInfo.class);
     }
 
     @Override

--- a/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/parsers/ReviewerInfosParser.java
+++ b/src/main/java/com/urswolfer/gerrit/client/rest/http/changes/parsers/ReviewerInfosParser.java
@@ -19,6 +19,7 @@ package com.urswolfer.gerrit.client.rest.http.changes.parsers;
 import com.google.common.reflect.TypeToken;
 import com.google.gerrit.extensions.api.changes.AddReviewerResult;
 import com.google.gerrit.extensions.api.changes.ReviewerInfo;
+import com.google.gerrit.extensions.api.changes.ReviewerResult;
 import com.google.gerrit.extensions.common.SuggestedReviewerInfo;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -59,5 +60,9 @@ public class ReviewerInfosParser {
 
     public AddReviewerResult parseAddReviewerResult(JsonElement result) {
         return gson.fromJson(result, AddReviewerResult.class);
+    }
+
+    public ReviewerResult parseReviewerResult(JsonElement result) {
+        return gson.fromJson(result, ReviewerResult.class);
     }
 }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/accounts/AccountsParserTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/accounts/AccountsParserTest.java
@@ -60,7 +60,10 @@ public class AccountsParserTest extends AbstractParserTest {
         AccountDetailInfo accountDetailInfo = accountsParser.parseAccountDetailInfo(jsonElement);
         Truth.assertThat(accountDetailInfo.registeredOn).isNotNull();
         Truth.assertThat(accountDetailInfo.inactive).isTrue();
-        Truth.assertThat(accountDetailInfo).isEqualTo(johnDoe);
+        AccountInfo expectedJohnDoe = new AccountInfo(1000003);
+        johnDoe.copyTo(expectedJohnDoe);
+        expectedJohnDoe.inactive = true;
+        Truth.assertThat(accountDetailInfo).isEqualTo(expectedJohnDoe);
     }
 
     @Test

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
@@ -199,7 +199,7 @@ public class ChangeApiRestClientTest {
     public void testMove() throws Exception {
         GerritRestClient gerritRestClient = getGerritRestClient(
             "/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/move",
-            "{\"destination_branch\":\"destination_branch\"}"
+            "{\"destination_branch\":\"destination_branch\",\"keep_all_votes\":false}"
         );
         ChangesRestClient changesRestClient = getChangesRestClient(gerritRestClient);
         changesRestClient.id("myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940").move("destination_branch");
@@ -211,7 +211,7 @@ public class ChangeApiRestClientTest {
     public void testMoveWithMessage() throws Exception {
         GerritRestClient gerritRestClient = getGerritRestClient(
             "/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/move",
-            "{\"message\":\"Move to desination_branch\",\"destination_branch\":\"destination_branch\"}"
+            "{\"message\":\"Move to desination_branch\",\"destination_branch\":\"destination_branch\",\"keep_all_votes\":false}"
         );
         ChangesRestClient changesRestClient = getChangesRestClient(gerritRestClient);
         MoveInput moveInput = new MoveInput();
@@ -884,7 +884,7 @@ public class ChangeApiRestClientTest {
     public void testRebaseChange() throws Exception {
         GerritRestClient gerritRestClient = getGerritRestClient(
                 "/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/rebase",
-                "{\"base\":\"1234\"}"
+                "{\"base\":\"1234\",\"allow_conflicts\":false,\"on_behalf_of_uploader\":false}"
         );
         ChangesRestClient changesRestClient = getChangesRestClient(gerritRestClient);
         RebaseInput rebaseInput = new RebaseInput();

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeApiRestClientTest.java
@@ -96,6 +96,24 @@ public class ChangeApiRestClientTest {
     }
 
     @Test
+    public void testAddReviewerWithReviewerInput() throws Exception {
+        GerritRestClient gerritRestClient = getGerritRestClient(
+                "/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/reviewers",
+                "{\"reviewer\":\"jdoe\",\"confirmed\":true}");
+        ChangesRestClient changesRestClient = getChangesRestClient(gerritRestClient);
+
+        ChangeApi changeApi = changesRestClient.id("myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940");
+
+        ReviewerInput input = new ReviewerInput();
+        input.reviewer = "jdoe";
+        input.confirmed = true;
+
+        changeApi.addReviewer(input);
+
+        EasyMock.verify(gerritRestClient);
+    }
+
+    @Test
     public void testPublish() throws Exception {
         GerritRestClient gerritRestClient = new GerritRestClientBuilder()
                 .expectPost("/changes/myProject~master~I8473b95934b5732ac55d26311a706c9c2bde9940/publish")

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeEditApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/ChangeEditApiRestClientTest.java
@@ -122,7 +122,7 @@ public class ChangeEditApiRestClientTest {
                 "some text goes here", RestClient.HttpVerb.PUT_TEXT_PLAIN, response)
             .get();
         FileContentInput input = new FileContentInput();
-        input.binary_content = "some text goes here";
+        input.binaryContent = "some text goes here";
         getEditApiClient(gerritRestClient,null,"1").modifyFile("dir/file1",input);
         EasyMock.verify(gerritRestClient);
     }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/RevisionApiRestClientTest.java
@@ -27,6 +27,7 @@ import com.google.gerrit.extensions.common.RobotCommentInfo;
 import com.google.gerrit.extensions.common.TestSubmitRuleInput;
 import com.google.gerrit.extensions.restapi.BinaryResult;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import com.urswolfer.gerrit.client.rest.http.GerritRestClient;
 import com.urswolfer.gerrit.client.rest.http.accounts.AccountsParser;
 import com.urswolfer.gerrit.client.rest.http.changes.parsers.*;
@@ -131,7 +132,9 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
     @Test(dataProvider = "TestCases")
     public void testSubmit(RevisionApiTestCase testCase) throws Exception {
         GerritRestClient gerritRestClient = new GerritRestClientBuilder()
-                .expectPost(testCase.submitUrl, "{\"wait_for_merge\":false,\"notify\":\"ALL\"}")
+                .expectPost(testCase.submitUrl, "{\"wait_for_merge\":false,\"notify\":\"ALL\"}",
+                    JsonParser.parseString("{}"))
+                .expectGetGson()
                 .expectGetGson()
                 .get();
 
@@ -188,7 +191,7 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
     @Test(dataProvider = "TestCases")
     public void testRebase(RevisionApiTestCase testCase) throws Exception {
         GerritRestClient gerritRestClient = new GerritRestClientBuilder()
-            .expectPost(testCase.rebaseUrl, "{}")
+            .expectPost(testCase.rebaseUrl, "{\"allow_conflicts\":false,\"on_behalf_of_uploader\":false}")
             .expectGetGson()
             .get();
 
@@ -202,7 +205,9 @@ public class RevisionApiRestClientTest extends AbstractParserTest {
     @Test(dataProvider = "TestCases")
     public void testSubmitWithSubmitInput(RevisionApiTestCase testCase) throws Exception {
         GerritRestClient gerritRestClient = new GerritRestClientBuilder()
-                .expectPost(testCase.submitUrl, "{\"wait_for_merge\":true,\"on_behalf_of\":\"jdoe\",\"notify\":\"ALL\"}")
+                .expectPost(testCase.submitUrl, "{\"wait_for_merge\":true,\"on_behalf_of\":\"jdoe\",\"notify\":\"ALL\"}",
+                    JsonParser.parseString("{}"))
+                .expectGetGson()
                 .expectGetGson()
                 .get();
 

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/parsers/ReviewerInfosParserTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/changes/parsers/ReviewerInfosParserTest.java
@@ -19,6 +19,7 @@ package com.urswolfer.gerrit.client.rest.http.changes.parsers;
 import com.google.common.truth.Truth;
 import com.google.gerrit.extensions.api.changes.AddReviewerResult;
 import com.google.gerrit.extensions.api.changes.ReviewerInfo;
+import com.google.gerrit.extensions.api.changes.ReviewerResult;
 import com.google.gerrit.extensions.common.SuggestedReviewerInfo;
 import com.google.gson.JsonElement;
 import com.urswolfer.gerrit.client.rest.http.common.AbstractParserTest;
@@ -69,6 +70,15 @@ public class ReviewerInfosParserTest extends AbstractParserTest {
         Truth.assertThat(addReviewerResult.input).isEqualTo("john.doe@example.com");
         Truth.assertThat(addReviewerResult.reviewers.size()).isEqualTo(1);
         Truth.assertThat(addReviewerResult.reviewers.get(0)._accountId).isEqualTo(1000096);
+    }
+
+    @Test
+    public void testParseReviewerResult() throws Exception {
+        JsonElement jsonElement = getJsonElement("addreviewer.json");
+        ReviewerResult reviewerResult = reviewerInfoParser.parseReviewerResult(jsonElement);
+        Truth.assertThat(reviewerResult.input).isEqualTo("john.doe@example.com");
+        Truth.assertThat(reviewerResult.reviewers.size()).isEqualTo(1);
+        Truth.assertThat(reviewerResult.reviewers.get(0)._accountId).isEqualTo(1000096);
     }
 
 }

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/projects/BranchApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/projects/BranchApiRestClientTest.java
@@ -52,7 +52,7 @@ public class BranchApiRestClientTest {
     @Test
     public void testCreateBranch() throws Exception {
         GerritRestClient gerritRestClient = new GerritRestClientBuilder()
-            .expectPut("/projects/sandbox/branches/some-feature", "{}", MOCK_JSON_ELEMENT)
+            .expectPut("/projects/sandbox/branches/some-feature", "{\"create_empty_commit\":false}", MOCK_JSON_ELEMENT)
             .expectGetGson()
             .get();
         ProjectsRestClient projectsRestClient = new ProjectsRestClient(gerritRestClient, null, null, null, null);

--- a/src/test/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectApiRestClientTest.java
+++ b/src/test/java/com/urswolfer/gerrit/client/rest/http/projects/ProjectApiRestClientTest.java
@@ -194,7 +194,8 @@ public class ProjectApiRestClientTest {
                     "\"description\":\"Feel free to play in the sandbox!\"," +
                     "\"permissions_only\":false," +
                     "\"create_empty_commit\":false," +
-                    "\"branches\":[\"master\",\"releases\"]}",
+                    "\"branches\":[\"master\",\"releases\"]," +
+                    "\"init_only\":false}",
                 MOCK_JSON_ELEMENT)
             .expectGetGson()
             .get();


### PR DESCRIPTION
## Summary

Refreshes the vendored Gerrit extension API/model classes under `com/google/gerrit/*` to match current upstream Gerrit.

- Updated existing vendored interfaces/DTOs to their current upstream content, restoring this repo's local `NotImplemented`-stub convention for every API interface and re-applying the established pattern of commenting out members that pull in server-only plugin SPI (`webui.TopMenu`, `webui.UiAction`) that this client doesn't vendor.
- Added new upstream interfaces/DTOs needed to keep implementing against the bumped API (e.g. `FlowApi`, `CachesApi`, `ExperimentApi`, `SubmitRequirementApi`, `ReviewerInput`/`ReviewerResult`, the `Flow*` and `SubmitRequirement*` models, `restapi.Response`/`BadRequestException`), including new small dependencies (`common.UsedAt`, `common.ConvertibleToProto`, `annotations.ExtensionPoint`, `auth.AuthTokenInfo`/`AuthTokenInput`) that those files require to compile. `ChangeIdentifier` and `ChangeInfoDifference` are hand-written without `@AutoValue` to avoid pulling in a new annotation-processor build dependency.
- Left untouched the few vendored files that no longer have an upstream counterpart but are still exercised by our own client code (`AddReviewerInput`/`AddReviewerResult`, `AssigneeInput`, `RobotCommentApi`, `RobotCommentInfo`, `StarsInput`), consistent with this repo's existing practice for deprecated/removed upstream surface.
- Made the minimal client-code changes forced by real upstream signature/field changes so the project keeps compiling and behaving correctly: `ChangeApi.addReviewer`/`ChangesRestClient` query building, `RevisionApi.submit`'s new `ChangeInfo` return type, removed `publish()`/`robotComments()`/`delete()`/`submitPreview()` methods, renamed `FileContentInput` and `LabelDefinitionInput` fields, removed `DiffRequest#context`, plus matching test updates.
- **Preserves backward compatibility** for existing implementers/callers of this library: every interface method, field, and enum constant that upstream Gerrit removed (mostly the "draft change" and "assignee" features, or a superseded representation like `LabelDefinitionInput`'s copy-score booleans versus `copyCondition`) is restored as `@Deprecated`, with a comment explaining why it was removed upstream, along with matching `NotImplemented` stubs where applicable. This is also why `com.google.gwtorm.server.StandardKeyEncoder` stays in the tree — `Changes.QueryRequest.encode()` still needs it.

## Test plan

- [x] `mvn clean compile` — clean
- [x] `mvn clean test-compile` — clean
- [x] `mvn clean test` — 350 tests run, only 4 pre-existing failures (an XStream/JDK-module-access incompatibility unrelated to this change; verified identical failures on pre-bump `master`)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01GK5ovyTsKF77ZLQAhFhY2C